### PR TITLE
Volume slider now reflects volume level

### DIFF
--- a/js/Singularity/singularity.js
+++ b/js/Singularity/singularity.js
@@ -95,7 +95,7 @@ addLayer("s", {
                         ["raw-html", function () { return "<button class=opt onclick=toggleOpt('toggleHotkey'); needsCanvasUpdate = true>Toggle Hotkeys</button>"}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
                     ]],
                     ["blank", "25px"],
-                    ["raw-html", function () { return "</td><td><div style=margin: 0 10px><input type=range id=volume name=Music Volume min=1 max=10 value=10 oninput=updateMusicVolume()><br>"}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
+                    ["raw-html", function () { return "</td><td><div style=margin: 0 10px><input type=range id=volume name=Music Volume min=1 max=10 value=" + options.musicVolume + " oninput=updateMusicVolume()><br>"}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
                     ["blank", "25px"],
                     ["raw-html", function () { return "Volume: " + options.musicVolume}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
                         ["raw-html", function () { return "Autosave: " + options.autosave}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -431,7 +431,7 @@ addLayer("in", {
                         ["raw-html", function () { return "<button class=opt onclick=toggleOpt('toggleHotkey'); needsCanvasUpdate = true>Toggle Hotkeys</button>"}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
                     ]],
                     ["blank", "25px"],
-                    ["raw-html", function () { return "</td><td><div style=margin: 0 10px><input type=range id=volume name=Music Volume min=1 max=10 value=10 oninput=updateMusicVolume()><br>"}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
+                    ["raw-html", function () { return "</td><td><div style=margin: 0 10px><input type=range id=volume name=Music Volume min=1 max=10 value=" + options.musicVolume + " oninput=updateMusicVolume()><br>"}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
                     ["blank", "25px"],
                     ["raw-html", function () { return "Volume: " + options.musicVolume}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
                         ["raw-html", function () { return "Autosave: " + options.autosave}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],

--- a/js/layers.js
+++ b/js/layers.js
@@ -498,7 +498,7 @@ addLayer("i", {
                         ["raw-html", function () { return "<button class=opt onclick=toggleOpt('toggleHotkey'); needsCanvasUpdate = true>Toggle Hotkeys</button>"}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
                     ]],
                         ["blank", "25px"],
-                        ["raw-html", function () { return "</td><td><div style=margin: 0 10px><input type=range id=volume name=Music Volume min=1 max=10 value=10 oninput=updateMusicVolume()><br>"}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
+                        ["raw-html", function () { return "</td><td><div style=margin: 0 10px><input type=range id=volume name=Music Volume min=1 max=10 value=" + options.musicVolume + " oninput=updateMusicVolume()><br>"}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
                         ["blank", "25px"],
                         ["raw-html", function () { return "Volume: " + options.musicVolume}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],
                         ["raw-html", function () { return "Autosave: " + options.autosave}, { "color": "white", "font-size": "18px", "font-family": "monospace" }],


### PR DESCRIPTION
Updates the Settings pages on singularity, infinity, and layers to use `options.musicVolume` instead of a magic number.

---

Original bug from Discord: [link](https://discord.com/channels/850817562040467556/1291854365581377629/1293307279692533960)

**Summary**: volume slider does not match volume level

**Replication**:
- Go to Settings
- Set volume to 6
- Go to Features
- Go to Settings

**Expected behavior**: volume slider should be at the 6 position

**Actual behavior**: volume slider is set to the 10 position

**Notes**:
- From checking in `.../js/layers.js:501-503`, it looks like `#volume` should be set to `options.musicVolume` at some point
- Looking at `.../js/utils/options.js:23-26`, function `updateMusicVolume()` sets `options.musicVolume` from the value of `#volume`
- I don't see a function to set `#volume` from `options.musicVolume` (i.e. I see volume initialization code in `.../js/game.js:604-671`, but nothing else relevant)