### PR TITLE
Code now fixes/guards against negative saved grass (i.e. fix disappearing grass)

### DIFF
--- a/js/grass.js
+++ b/js/grass.js
@@ -233,6 +233,13 @@
     },
     loadGrass()
     {
+        // savedGrass should never be negative!
+        if (player.g.savedGrass < 0) {
+            player.g.savedGrass = player.g.grassCount > 0
+                ? player.g.grassCount
+                : 0
+        }
+
         removeAllGrass();
         createGrass(player.g.savedGrass);
         player.g.grassCount = player.g.savedGrass
@@ -770,6 +777,16 @@
 })
 
 function createGrass(quantity) {
+    // This _shouldn't_ happen, but there existed cases where e.g.
+    // player.g.savedGrass somehow got a massively-negative number and
+    // as a result, the loop down below never finished.
+    // We now dump some info to console if this happens.
+    if (quantity < 0) {
+        console.log('%cCalled .../js/grass.js:createGrass with negative quantity!', 'color:red; font-size: 150%; font-weight: bold')
+      console.log(`%cInfo for the devs: fx: .../js/grass.js:createGrass; quantity: ${quantity}; player.g.grassCount ${player.g.grassCount}; player.g.savedGrass: ${player.g.savedGrass}`, 'color: yellow; font-size: 125%')
+        return
+    }
+
     const spawnArea = document.getElementById('spawn-area');
     const spawnAreaRect = spawnArea?.getBoundingClientRect();
 


### PR DESCRIPTION
Whether by save corruption or other unknown bugs, `player.g.savedGrass` would sometimes go negative, which caused a couple bugs:
- `.../js/grass.js:createGrass` would never stop running, thus unnecessarily eating resources.
- Switching from/to the grass microtab in the grass layer would cause grass to inexplicably disappear.

This PR adds code to guard against negative saved grass, and fixes negative saved grass if it's encountered in a save.  While this doesn't address the root cause of saved grass going negative, it _does_ fix the negative value when/if it's encountered in-game.

Further investigation as to the causes of negative saved grass is recommended, but might be triaged as low-priority now that this band-aid is in place.