### PR TITLE
Debug and refactor grass.js update code

### DIFF
--- a/js/grass.js
+++ b/js/grass.js
@@ -52,7 +52,7 @@
             buyUpgrade("g", 18)
             buyUpgrade("g", 19)
             buyUpgrade("g", 21)
-        }   
+        }
     },
     nodeStyle() {
     },
@@ -116,16 +116,21 @@
             player.g.grassCount = new Decimal(0)
         }
 
-        removeAllGrass();
-        createGrass(player.g.grassCount);
+        removeAllGrass()
+        createGrass(player.g.grassCount)
     },
     unloadGoldGrass() {
         // N.B. this space intentionally left blank
     },
     loadGoldGrass()
     {
-        createGoldenGrass(player.g.savedGoldGrass);
-        player.g.goldGrassCount = player.g.savedGoldGrass
+        // goldGrassCount should never be negative!
+        if (player.g.goldGrassCount < 0) {
+            player.g.goldGrassCount = new Decimal(0)
+        }
+
+        removeAllGoldGrass()
+        createGoldGrass(player.g.goldGrassCount)
     },
     branches: ["t"],
     clickables: {
@@ -173,7 +178,7 @@
                 return player.p.prestigePoints.pow(0.05).div(9).add(1)
             },
             effectDisplay() { return format(upgradeEffect(this.layer, this.id))+"x" }, // Add formatting to the effect
-        }, 
+        },
         12:
         {
             title: "Grass Upgrade II",
@@ -187,7 +192,7 @@
                 return player.g.grass.pow(0.3).div(7).add(1)
             },
             effectDisplay() { return format(upgradeEffect(this.layer, this.id))+"x" }, // Add formatting to the effect
-        }, 
+        },
         13:
         {
             title: "Grass Upgrade III",
@@ -197,7 +202,7 @@
             currencyLocation() { return player.g },
             currencyDisplayName: "Grass",
             currencyInternalName: "grass",
-        }, 
+        },
         14:
         {
             title: "Grass Upgrade IV",
@@ -207,7 +212,7 @@
             currencyLocation() { return player.g },
             currencyDisplayName: "Grass",
             currencyInternalName: "grass",
-        }, 
+        },
         15:
         {
             title: "Grass Upgrade V",
@@ -217,7 +222,7 @@
             currencyLocation() { return player.g },
             currencyDisplayName: "Grass",
             currencyInternalName: "grass",
-        }, 
+        },
         16:
         {
             title: "Grass Upgrade VI",
@@ -310,7 +315,7 @@
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
-    
+
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
                 if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
@@ -342,7 +347,7 @@
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
-    
+
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
                 if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
@@ -374,7 +379,7 @@
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
-    
+
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
                 if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
@@ -406,7 +411,7 @@
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
-    
+
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
                 if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
@@ -438,7 +443,7 @@
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
-    
+
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
                 if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
@@ -470,7 +475,7 @@
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
-    
+
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
                 if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
@@ -502,7 +507,7 @@
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
-    
+
                 let max = Decimal.affordGeometricSeries(player.g.goldGrass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
                 if (!hasMilestone("r", 13)) player.g.goldGrass = player.g.goldGrass.sub(cost)
@@ -534,7 +539,7 @@
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
-    
+
                 let max = Decimal.affordGeometricSeries(player.g.goldGrass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
                 if (!hasMilestone("r", 13)) player.g.goldGrass = player.g.goldGrass.sub(cost)
@@ -566,7 +571,7 @@
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
-    
+
                 let max = Decimal.affordGeometricSeries(player.g.goldGrass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
                 if (!hasMilestone("r", 13)) player.g.goldGrass = player.g.goldGrass.sub(cost)
@@ -638,7 +643,7 @@
                 ]
             },
         },
-    }, 
+    },
 
     tabFormat: [
                         ["raw-html", function () { return "You have <h3>" + format(player.g.grass) + "</h3> grass, which boost leaf gain by <h3>x" + format(player.g.grassEffect) + "." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
@@ -832,7 +837,7 @@ const updateGrass = (delta) => {
     // -------------------------
 
     player.g.grassVal = player.g.grassVal
-        .pow(buyableEffect('rm', 25)) 
+        .pow(buyableEffect('rm', 25))
 
     // -------------------------
     // REORDERING BOUNDARY: above stays above, below stays below
@@ -852,13 +857,13 @@ const updateGrass = (delta) => {
     // =================================================================
     // Spawn-time logic
 
-    player.g.grassReq = new Decimal(4) 
+    player.g.grassReq = new Decimal(4)
         .div(buyableEffect('g', 12))
 
     // =================================================================
     // Cap logic
 
-    player.g.grassCap = new Decimal(100) 
+    player.g.grassCap = new Decimal(100)
         .add(buyableEffect('g', 13))
 
     if (hasUpgrade('g', 18)) {
@@ -872,79 +877,133 @@ const updateGrass = (delta) => {
 }
 
 const updateGoldGrass = (delta) => {
-    // Pre-calculate how much grass we're adding this tick
-    const goldGrassToAdd = new Decimal(1).mul(delta)
-
-    player.g.goldGrassVal = new Decimal(1)
-    player.g.goldGrassVal = player.g.goldGrassVal.mul(buyableEffect("g", 17))
-    player.g.goldGrassVal = player.g.goldGrassVal.mul(buyableEffect("t", 18))
-    player.g.goldGrassVal = player.g.goldGrassVal.mul(buyableEffect("m", 13))
-    player.g.goldGrassVal = player.g.goldGrassVal.mul(player.cb.commonPetEffects[3][1])
-    if (hasUpgrade("ip", 24) && !inChallenge("ip", 14)) player.g.goldGrassVal = player.g.goldGrassVal.add(upgradeEffect("ip", 24))
-    player.g.goldGrassVal = player.g.goldGrassVal.mul(player.cb.rarePetEffects[4][1])
-    player.g.goldGrassVal = player.g.goldGrassVal.mul(buyableEffect("r", 11))
-    player.g.goldGrassVal = player.g.goldGrassVal.mul(buyableEffect("rm", 26)) 
-
-    player.g.goldGrass = player.g.goldGrass.add(player.g.goldGrassVal.mul(buyableEffect("gh", 18).mul(delta)))
-
-    player.g.goldGrassReq = new Decimal(40) 
-    if (hasUpgrade("g", 16)) player.g.goldGrassReq = player.g.goldGrassReq.div(1.3)
-    player.g.goldGrassReq = player.g.goldGrassReq.div(buyableEffect("gh", 12))
-    player.g.goldGrassReq = player.g.goldGrassReq.div(player.cb.rarePetEffects[2][1])
-
-    player.g.goldGrassCap = new Decimal(15) 
-    player.g.goldGrassCap = player.g.goldGrassCap.add(buyableEffect("g", 18))
-    if (hasUpgrade("g", 18)) player.g.goldGrassCap = player.g.goldGrassCap.add(6)
-
-    // Golden grass handling
-    if (hasUpgrade("g", 13))
-    {
-        if (player.subtabs["g"]['stuff'] == 'Golden Grass' && player.tab == "g" && player.g.isGoldGrassLoaded == false)
-        {
-            layers.g.loadGoldGrass();
-        }
-        if (player.g.isGoldGrassLoaded)
-        {
-            layers.g.loadGoldGrass();
-        }
-        if (!(player.subtabs["g"]['stuff'] == 'Golden Grass') && !(player.tab == "g") && player.g.isGoldGrassLoaded == true)
-        {
-            layers.g.unloadGoldGrass();
-        }
-        if (player.subtabs["g"]['stuff'] == 'Golden Grass' && player.tab == "g")
-        {
-            player.g.isGoldGrassLoaded = true
-            if (player.g.goldGrassCount < player.g.goldGrassCap) player.g.goldGrassTimer = player.g.goldGrassTimer.add(goldGrassToAdd)
-            if (player.g.goldGrassTimer.gt(player.g.goldGrassReq) && player.g.goldGrassCount < player.g.goldGrassCap)
-            {
-                createGoldenGrass(1);
-                player.g.savedGoldGrass++;
-                player.g.goldGrassTimer = new Decimal(0)
-            }
-        } else if (!player.g.isGoldGrassLoaded)
-        {
-            player.g.isGoldGrassLoaded = false
-            removeAllGoldGrass();
-            if (player.g.goldGrassCount < player.g.goldGrassCap) player.g.goldGrassTimer = player.g.goldGrassTimer.add(goldGrassToAdd)
-            if (player.g.goldGrassTimer.gt(player.g.goldGrassReq) && player.g.savedGoldGrass < player.g.goldGrassCap)
-            {
-                player.g.savedGoldGrass++;
-                player.g.goldGrassTimer = new Decimal(0)
-            }
-        } else
-        {
-            player.g.isGoldGrassLoaded = false
-            if (player.g.goldGrassCount < player.g.goldGrassCap) player.g.goldGrassTimer = player.g.goldGrassTimer.add(goldGrassToAdd)
-        }
-        if (player.g.goldGrassCount < 0)
-        {
-            player.g.goldGrassCount = new Decimal(0)
-        }
+    // Sanity check: gold grass should never go negative!
+    if (player.g.goldGrassCount.lt(0)) {
+        player.g.goldGrassCount = new Decimal(0)
     }
 
-    player.g.goldGrassEffect = player.g.goldGrass.pow(0.7).mul(0.15).add(1)
+    // Kick out early if we don't have access
+    if (!hasUpgrade('g', 13)) {
+        return
+    }
+
+    // Pre-calculate how much grass we're adding this tick
+    const seconds = new Decimal(1).mul(delta)
+
+    // =================================================================
+    // Timer logic
+
+    // Timer is always running if we're below grass cap
+    const belowGoldGrassCap = player.g.goldGrassCount.lt(player.g.goldGrassCap)
+    if (belowGoldGrassCap) {
+        player.g.goldGrassTimer = player.g.goldGrassTimer.add(seconds)
+    }
+
+    const passedGoldGrassSpawnTime =
+        player.g.goldGrassTimer.gte(player.g.goldGrassReq)
+    if (passedGoldGrassSpawnTime && belowGoldGrassCap) {
+        const goldGrassToAdd = player.g.goldGrassTimer
+            .div(player.g.goldGrassReq)
+            .floor()
+
+        // Add grass
+        if (belowGoldGrassCap) {
+            player.g.goldGrassCount = player.g.goldGrassCount
+                .add(goldGrassToAdd)
+        }
+
+        // Sanity check: respect the cap
+        const aboveGoldGrassCap =
+            player.g.goldGrassCount.gt(player.g.goldGrassCap)
+        if (aboveGoldGrassCap) {
+            player.g.goldGrassCount = player.g.goldGrassCap
+        }
+
+        // Only create when we're loaded
+        if (player.g.isGoldGrassLoaded) {
+            createGoldGrass(goldGrassToAdd)
+        }
+
+        // Reset the timer
+        player.g.goldGrassTimer = new Decimal(0)
+    } else if (passedGoldGrassSpawnTime && !belowGoldGrassCap) {
+        // Reset the timer
+        player.g.goldGrassTimer = new Decimal(0)
+    }
+    // =================================================================
+    // Effect logic
+
+    player.g.goldGrassEffect = player.g.goldGrass
+        .pow(0.7)
+        .mul(0.15)
+        .add(1)
+
     if (hasUpgrade("g", 22)) {
-        player.g.goldGrassEffect = player.g.goldGrassEffect.pow(6)
+        player.g.goldGrassEffect = player.g.goldGrassEffect
+            .pow(6)
+    }
+
+    // =================================================================
+    // Currency logic
+
+    player.g.goldGrass = player.g.goldGrass
+        .add(player.g.goldGrassVal
+            .mul(buyableEffect("gh", 18)
+                .mul(delta)
+            )
+        )
+
+    // =================================================================
+    // Value logic
+
+    player.g.goldGrassVal = new Decimal(1)
+        .mul(buyableEffect('g', 17))
+        .mul(buyableEffect('t', 18))
+        .mul(buyableEffect('m', 13))
+        .mul(player.cb.commonPetEffects[3][1])
+
+    // -------------------------
+    // REORDERING BOUNDARY: above stays above, below stays below
+    // -------------------------
+
+    // Infinity Points upgrade: Upgrade (2, 4)
+    // Infinity Points challenge: Challenge 14
+    if (hasUpgrade('ip', 24) && !inChallenge('ip', 14)) {
+        player.g.goldGrassVal = player.g.goldGrassVal
+            .add(upgradeEffect("ip", 24))
+    }
+
+    // -------------------------
+    // REORDERING BOUNDARY: above stays above, below stays below
+    // -------------------------
+
+    player.g.goldGrassVal = player.g.goldGrassVal
+        .mul(player.cb.rarePetEffects[4][1])
+        .mul(buyableEffect('r', 11))
+        .mul(buyableEffect('rm', 26))
+
+    // =================================================================
+    // Spawn-time logic
+
+    player.g.goldGrassReq = new Decimal(40)
+    if (hasUpgrade("g", 16)) {
+        player.g.goldGrassReq = player.g.goldGrassReq
+            .div(1.3)
+    }
+
+    player.g.goldGrassReq = player.g.goldGrassReq
+        .div(buyableEffect("gh", 12))
+        .div(player.cb.rarePetEffects[2][1])
+
+    // =================================================================
+    // Cap logic
+
+    player.g.goldGrassCap = new Decimal(15)
+        .add(buyableEffect("g", 18))
+
+    if (hasUpgrade("g", 18)) {
+        player.g.goldGrassCap = player.g.goldGrassCap
+            .add(6)
     }
 }
 
@@ -988,7 +1047,7 @@ function createGrass(quantity) {
         greenSquare.classList.add('green-square');
 
         spawnArea.appendChild(greenSquare); // Append to spawnArea instead of document.body
-        
+
         // Function to check if cursor is within 150px radius of the greenSquare
         function checkCursorDistance(event) {
             const cursorX = event.clientX;
@@ -1004,7 +1063,8 @@ function createGrass(quantity) {
             if (distance <= 100) {
                 removeGrass(greenSquare);
                 player.g.grassCount = player.g.grassCount.sub(1);
-                player.g.grass = player.g.grass.add(player.g.grassVal);
+                player.g.grass = player.g.grass
+                    .add(player.g.grassVal);
 
                 // Remove the mousemove listener once grass is collected
                 document.removeEventListener('mousemove', checkCursorDistance);
@@ -1047,7 +1107,7 @@ window.addEventListener('load', function() {
 });
 
 
-function createGoldenGrass(quantity) {
+function createGoldGrass(quantity) {
     const spawnArea = document.getElementById('gold-spawn-area');
     const spawnAreaRect = spawnArea?.getBoundingClientRect();
 
@@ -1092,9 +1152,9 @@ function createGoldenGrass(quantity) {
             // If the cursor is within 100 pixels, remove the golden grass square
             if (distance <= 100) {
                 removeGrass(goldSquare);
-                player.g.goldGrassCount--; // Decrease grass count
-                player.g.savedGoldGrass--; // Decrease saved grass count
-                player.g.goldGrass = player.g.goldGrass.add(player.g.goldGrassVal);
+                player.g.goldGrassCount = player.g.goldGrassCount.sub(1)
+                player.g.goldGrass = player.g.goldGrass
+                    .add(player.g.goldGrassVal);
 
                 // Remove the mousemove listener once the golden grass is collected
                 document.removeEventListener('mousemove', checkCursorDistance);
@@ -1103,8 +1163,6 @@ function createGoldenGrass(quantity) {
 
         // Add the mousemove event listener to check the distance from the cursor
         document.addEventListener('mousemove', checkCursorDistance);
-
-        player.g.goldGrassCount++; // Increase golden grass count
     }
 }
 

--- a/js/grass.js
+++ b/js/grass.js
@@ -80,15 +80,13 @@
         // DEBUGGING OUTPUT
         //logOnce('updateEnter', `.../js/grass.js:update() ${JSON.stringify(state)}`)
 
-        // Unload grass if we leave its microtab
+        // Grass isn't loaded if we leave its microtab
         if (player.g.isGrassLoaded && !state.onGrassMicrotab) {
-            layers.g.unloadGrass()
             player.g.isGrassLoaded = false
         }
 
-        // Unload golden grass if we leave its microtab
+        // Golden grass isn't loaded if we leave its microtab
         if (player.g.isGoldGrassLoaded && !state.onGoldGrassMicrotab) {
-            layers.g.unloadGoldGrass()
             player.g.isGoldGrassLoaded = false
         }
 
@@ -108,30 +106,21 @@
         updateGrass(delta)
         updateGoldGrass(delta)
     },
-    unloadGrass()
-    {
-        // XXX: let the timer keep its time
-        //player.g.grassTimer = new Decimal(0)
-        player.g.grassCount = new Decimal(0)
+    unloadGrass() {
+        // N.B. this space intentionally left blank
     },
     loadGrass()
     {
-        // savedGrass should never be negative!
-        if (player.g.savedGrass < 0) {
-            player.g.savedGrass = player.g.grassCount > 0
-                ? player.g.grassCount
-                : 0
+        // grassCount should never be negative!
+        if (player.g.grassCount < 0) {
+            player.g.grassCount = new Decimal(0)
         }
 
         removeAllGrass();
-        createGrass(player.g.savedGrass);
-        player.g.grassCount = player.g.savedGrass
+        createGrass(player.g.grassCount);
     },
-    unloadGoldGrass()
-    {
-        // XXX: let the timer keep its time
-        //player.g.goldGrassTimer = new Decimal(0)
-        player.g.goldGrassCount = new Decimal(0)
+    unloadGoldGrass() {
+        // N.B. this space intentionally left blank
     },
     loadGoldGrass()
     {
@@ -662,12 +651,12 @@
 
 const updateGrass = (delta) => {
     // Sanity check: grass should never go negative!
-    if (player.g.grassCount < 0) {
+    if (player.g.grassCount.lt(0)) {
         player.g.grassCount = new Decimal(0)
     }
 
     // Pre-calculate how much grass we're adding this tick
-    const grassToAdd = new Decimal(1).mul(delta)
+    const seconds = new Decimal(1).mul(delta)
 
     // Cap grass grow rate at 200
     // XXX: in what cases does this get pushed over 200, and why?
@@ -678,27 +667,40 @@ const updateGrass = (delta) => {
     // =================================================================
     // Timer logic
 
+    // DEBUGGING OUTPUT
+    //logOnce('grassTimer1', `grassCount:${player.g.grassCount}; grassCap: ${player.g.grassCap}; grassTimer:${player.g.grassTimer}`)
+
     // Timer is always running if we're below grass cap
-    // DEBUG
-    // logOnce('grassTimer1', `grassCount:${player.g.grassCount}; grassCap: ${player.g.grassCap}; grassTimer:${player.g.grassTimer}`)
-    if (player.g.grassCount < player.g.grassCap) {
-        player.g.grassTimer = player.g.grassTimer.add(grassToAdd)
+    const belowGrassCap = player.g.grassCount.lt(player.g.grassCap)
+    if (belowGrassCap) {
+        player.g.grassTimer = player.g.grassTimer.add(seconds)
     }
 
     const passedGrassSpawnTime = player.g.grassTimer.gte(player.g.grassReq)
-    const belowGrassCap = player.g.grassCount < player.g.grassCap
     if (passedGrassSpawnTime && belowGrassCap) {
+        const grassToAdd = player.g.grassTimer
+            .div(player.g.grassReq)
+            .floor()
+
         // Add grass
-        if (player.g.savedGrass < player.g.grassCap) {
-            player.g.savedGrass++;
+        if (belowGrassCap) {
+            player.g.grassCount = player.g.grassCount.add(grassToAdd)
+        }
+
+        // Sanity check: respect the cap
+        const aboveGrassCap = player.g.grassCount.gt(player.g.grassCap)
+        if (aboveGrassCap) {
+            player.g.grassCount = player.g.grassCap
         }
 
         // Only create when we're loaded
         if (player.g.isGrassLoaded) {
-            console.log('creating')
-            createGrass(1);
+            createGrass(grassToAdd)
         }
 
+        // Reset the timer
+        player.g.grassTimer = new Decimal(0)
+    } else if (passedGrassSpawnTime && !belowGrassCap) {
         // Reset the timer
         player.g.grassTimer = new Decimal(0)
     }
@@ -707,100 +709,165 @@ const updateGrass = (delta) => {
     // Effect logic
 
     // XXX: is the intent to update the effect before or after adding grass?
-    player.g.grassEffect = player.g.grass.mul(0.3).pow(0.7).add(1)
+    player.g.grassEffect = player.g.grass
+        .mul(0.3)
+        .pow(0.7)
+        .add(1)
 
     // =================================================================
     // Currency logic
 
     // Add currency
     // Modified by Grasshop, buyable, Grass Study 1
-    player.g.grass = player.g.grass.add(
-        player.g.grassVal.mul(buyableEffect("gh", 11).mul(delta)))
+    player.g.grass = player.g.grass
+        .add(player.g.grassVal
+            .mul(buyableEffect('gh', 11)
+                .mul(delta)
+            )
+        )
 
     // Rocket Fuel, upgrade: Rocket Fuel Upgrade 2
     // Straight 20% bonus
-    if (hasUpgrade("rf", 12)) {
-        player.g.grass = player.g.grass.add(
-            player.g.grassVal.mul(Decimal.mul(0.2, delta)))
+    if (hasUpgrade('rf', 12)) {
+        player.g.grass = player.g.grass
+            .add(player.g.grassVal
+                .mul(Decimal
+                    .mul(0.2, delta)
+                )
+            )
     }
 
     // Infinity Points, milestone: 4 Infinities
     // Straight 5% bonus
-    if (hasMilestone("ip", 13) && !inChallenge("ip", 14)) {
-        player.g.grass = player.g.grass.add(
-            player.g.grassVal.mul(Decimal.mul(0.05, delta)))
+    if (hasMilestone('ip', 13) && !inChallenge('ip', 14)) {
+        player.g.grass = player.g.grass
+            .add(player.g.grassVal
+                .mul(Decimal
+                    .mul(0.05, delta)
+                )
+            )
     }
 
     // =================================================================
     // Value logic
 
     player.g.grassVal = new Decimal(1)
-    player.g.grassVal = player.g.grassVal.mul(buyableEffect("g", 11))
+        .mul(buyableEffect('g', 11))
+        .mul(player.g.goldGrassEffect)
+        .mul(buyableEffect('t', 17))
+        .mul(player.gh.grasshopperEffects[4])
+        .mul(player.gh.fertilizerEffect)
+        .mul(buyableEffect('f', 1))
+        .mul(buyableEffect('f', 2))
+        .mul(buyableEffect('f', 3))
+        .mul(buyableEffect('f', 4))
+        .mul(buyableEffect('f', 5))
+        .mul(buyableEffect('f', 6))
+        .mul(buyableEffect('f', 7))
+        .mul(buyableEffect('f', 8))
+        .mul(player.cb.commonPetEffects[3][0])
+        .mul(player.d.diceEffects[5])
+        .mul(player.rf.abilityEffects[2])
+        .div(player.pe.pestEffect[4])
 
-    // Grass, upgrade: Grass Upgrade 1
-    if (hasUpgrade("g", 11)) {
-        player.g.grassVal = player.g.grassVal.mul(upgradeEffect("g", 11))
+    // Grass upgrade: Grass Upgrade 1
+    if (hasUpgrade('g', 11)) {
+        player.g.grassVal = player.g.grassVal
+            .mul(upgradeEffect('g', 11))
     }
 
-    player.g.grassVal = player.g.grassVal.mul(player.g.goldGrassEffect)
-    player.g.grassVal = player.g.grassVal.mul(buyableEffect("t", 17))
-    player.g.grassVal = player.g.grassVal.mul(player.gh.grasshopperEffects[4])
-    player.g.grassVal = player.g.grassVal.mul(player.gh.fertilizerEffect)
-    player.g.grassVal = player.g.grassVal.mul(buyableEffect("f", 1))
-    player.g.grassVal = player.g.grassVal.mul(buyableEffect("f", 2))
-    player.g.grassVal = player.g.grassVal.mul(buyableEffect("f", 3))
-    player.g.grassVal = player.g.grassVal.mul(buyableEffect("f", 4))
-    player.g.grassVal = player.g.grassVal.mul(buyableEffect("f", 5))
-    player.g.grassVal = player.g.grassVal.mul(buyableEffect("f", 6))
-    player.g.grassVal = player.g.grassVal.mul(buyableEffect("f", 7))
-    player.g.grassVal = player.g.grassVal.mul(buyableEffect("f", 8))
-    player.g.grassVal = player.g.grassVal.mul(player.cb.commonPetEffects[3][0])
-    player.g.grassVal = player.g.grassVal.mul(player.d.diceEffects[5])
-    player.g.grassVal = player.g.grassVal.mul(player.rf.abilityEffects[2])
-    if (hasUpgrade("ad", 14)) {
-        player.g.grassVal = player.g.grassVal.mul(upgradeEffect("ad", 14))
+    // AD upgrade: AD Upgrade 4
+    if (hasUpgrade('ad', 14)) {
+        player.g.grassVal = player.g.grassVal
+            .mul(upgradeEffect('ad', 14))
     }
-    player.g.grassVal = player.g.grassVal.div(player.pe.pestEffect[4])
-    if (inChallenge("ip", 13)) {
-        player.g.grassVal = player.g.grassVal.pow(0.75)
+
+    // -------------------------
+    // REORDERING BOUNDARY: above stays above, below stays below
+    // -------------------------
+
+    // IP challenge: Challenge 3
+    if (inChallenge('ip', 13)) {
+        player.g.grassVal = player.g.grassVal
+            .pow(0.75)
     }
-    if (inChallenge("ip", 13) || player.po.hex) {
-        player.g.grassVal = player.g.grassVal.mul(buyableEffect("h", 14))
+
+    // -------------------------
+    // REORDERING BOUNDARY: above stays above, below stays below
+    // -------------------------
+
+    // IP challenge: Challenge 3
+    if (inChallenge('ip', 13) || player.po.hex) {
+        player.g.grassVal = player.g.grassVal
+            .mul(buyableEffect('h', 14))
     }
+
+    // Antidebuff: Grass
     if (player.de.antidebuffIndex.eq(2)) {
-        player.g.grassVal = player.g.grassVal.mul(player.de.antidebuffEffect)
+        player.g.grassVal = player.g.grassVal
+            .mul(player.de.antidebuffEffect)
     }
-    if (inChallenge("tad", 11)) {
-        player.g.grassVal = player.g.grassVal.pow(0.4)
-    }
-    if (inChallenge("tad", 11)) {
-        player.g.grassVal = player.g.grassVal.pow(buyableEffect("de", 15))
-    }
-    player.g.grassVal = player.g.grassVal.mul(buyableEffect("gh", 33))
-    player.g.grassVal = player.g.grassVal.mul(player.r.timeCubeEffects[2])
-    player.g.grassVal = player.g.grassVal.pow(buyableEffect("rm", 25)) 
 
-    if (inChallenge("ip", 18) && player.g.grass.gt(player.g.grass.mul(0.4 * delta)))
-    {
-        player.g.grass = player.g.grass.sub(player.g.grass.mul(0.4 * delta))
+    // -------------------------
+    // REORDERING BOUNDARY: above stays above, below stays below
+    // -------------------------
+
+    // Tav's Domain challenge: Tav's Domain
+    if (inChallenge('tad', 11)) {
+        player.g.grassVal = player.g.grassVal
+            .pow(0.4)
+            .pow(buyableEffect('de', 15))
+    }
+
+    // -------------------------
+    // REORDERING BOUNDARY: above stays above, below stays below
+    // -------------------------
+
+    player.g.grassVal = player.g.grassVal
+        .mul(buyableEffect('gh', 33))
+        .mul(player.r.timeCubeEffects[2])
+
+    // -------------------------
+    // REORDERING BOUNDARY: above stays above, below stays below
+    // -------------------------
+
+    player.g.grassVal = player.g.grassVal
+        .pow(buyableEffect('rm', 25)) 
+
+    // -------------------------
+    // REORDERING BOUNDARY: above stays above, below stays below
+    // -------------------------
+
+    const grassAtC18Threshold = player.g.grass.gt(player.g.grass
+        .mul(0.4 * delta))
+
+    // IP challenge: Challenge 8
+    if (inChallenge('ip', 18) && grassAtC18Threshold) {
+        player.g.grass = player.g.grass
+            .sub(player.g.grass
+                .mul(0.4 * delta)
+            )
     }
 
     // =================================================================
     // Spawn-time logic
 
     player.g.grassReq = new Decimal(4) 
-    player.g.grassReq = player.g.grassReq.div(buyableEffect("g", 12))
+        .div(buyableEffect('g', 12))
 
     // =================================================================
     // Cap logic
 
     player.g.grassCap = new Decimal(100) 
-    player.g.grassCap = player.g.grassCap.add(buyableEffect("g", 13))
-    if (hasUpgrade("g", 18)) {
-        player.g.grassCap = player.g.grassCap.add(150)
+        .add(buyableEffect('g', 13))
+
+    if (hasUpgrade('g', 18)) {
+        player.g.grassCap = player.g.grassCap
+            .add(150)
     }
-    if (hasUpgrade("g", 19)) {
-        player.g.grassCap = player.g.grassCap.add(upgradeEffect("g", 19))
+    if (hasUpgrade('g', 19)) {
+        player.g.grassCap = player.g.grassCap
+            .add(upgradeEffect('g', 19))
     }
 }
 
@@ -883,12 +950,12 @@ const updateGoldGrass = (delta) => {
 
 function createGrass(quantity) {
     // This _shouldn't_ happen, but there existed cases where e.g.
-    // player.g.savedGrass somehow got a massively-negative number and
-    // as a result, the loop down below never finished.
-    // We now dump some info to console if this happens.
+    // player.g.savedGrass (when it used to exist) somehow got a
+    // massively-negative number and as a result, the loop down below
+    // never finished. We now dump some info to console if this happens.
     if (quantity < 0) {
         console.log('%cCalled .../js/grass.js:createGrass with negative quantity!', 'color:red; font-size: 150%; font-weight: bold')
-      console.log(`%cInfo for the devs: fx: .../js/grass.js:createGrass; quantity: ${quantity}; player.g.grassCount ${player.g.grassCount}; player.g.savedGrass: ${player.g.savedGrass}`, 'color: yellow; font-size: 125%')
+      console.log(`%cInfo for the devs: fx: .../js/grass.js:createGrass; quantity: ${quantity}; player.g.grassCount ${player.g.grassCount}`, 'color: yellow; font-size: 125%')
         return
     }
 
@@ -933,11 +1000,10 @@ function createGrass(quantity) {
 
             const distance = getDistance(cursorX, cursorY, squareCenterX, squareCenterY);
 
-            // If the cursor is within 150 pixels, remove the grass square
+            // If the cursor is within a certain pixel range, remove the grass square
             if (distance <= 100) {
                 removeGrass(greenSquare);
-                player.g.grassCount--; // Decrease grass count
-                player.g.savedGrass--; // Decrease saved grass count
+                player.g.grassCount = player.g.grassCount.sub(1);
                 player.g.grass = player.g.grass.add(player.g.grassVal);
 
                 // Remove the mousemove listener once grass is collected
@@ -947,8 +1013,6 @@ function createGrass(quantity) {
 
         // Add the mousemove event listener to check the distance from the cursor
         document.addEventListener('mousemove', checkCursorDistance);
-
-        player.g.grassCount++; // Increase grass count
     }
 }
 


### PR DESCRIPTION
This PR debugs and refactors the update code in `.../js/grass.js`, with these results:
- Grass and golden grass (hereafter "GGG") code has been split into separate functions, both called from the main `update` call
- GGG timers both correctly process in the background
- GGG timers start properly on load and tab change
- GGG timers save their state
- savedGrass/savedGoldGrass are no longer needed: references in `.../js/grass.js` have been removed
- Sub-phases of GGG updates have been marked and commented in their respective update functions
- Added GGG underflow and overflow guards
- Trailing whitespace removed
- Condensed calculation chains for GGG
- Maybe more stuff that didn't make it into the changelog

I have tried various ways to test for error cases, including:
- Spam-clicking to try to cause calculation errors
- Forcing overflow/underflow conditions manually via the console
- Forcing overflow/underflow conditions in version of the game prior to these changes, exporting the save, then importing it into this version of the game
- Messing with my computer's clock

This PR has been tested on my personal machine (Firefox in Windows 10).  While I'll go ahead and say "it works for me," the magnitude of these changes **_STRONGLY_** warrant extensive testing before being pushed to production.

YMMV, YHBW, glhf.