### PR TITLE
Update tav.js

### DIFF
--- a/js/tav.js
+++ b/js/tav.js
@@ -227,7 +227,7 @@
                 }
                 if (i == 9 && player.ta.buyables[31].gte(1))
                 {
-                    if (hasUpgrade("ta", 14) && player.ad.dimBoostAmount.lt(player.ta.dimboostLimit))
+                    if (hasUpgrade("ta", 14) && player.ad.dimBoostAmount.lt(player.ta.dimboostLimit) || !hasUpgrade("ta", 14))
                     {
                     if (player.ad.extraDimsGalaxiesLocked ? player.ad.dimensionAmounts[player.ad.dimBoostDimCost].gte(player.ad.dimBoostReq) && (player.ad.dimBoostAmount.lt(6)) : player.ad.dimensionAmounts[player.ad.dimBoostDimCost].gte(player.ad.dimBoostReq))
                     {
@@ -239,7 +239,7 @@
                 }
                 if (i == 10 && player.ta.buyables[32].gte(1))
                 {
-                    if (hasUpgrade("ta", 14) && player.ad.galaxyAmount.lt(player.ta.galaxyLimit))
+                    if (hasUpgrade("ta", 14) && player.ad.galaxyAmount.lt(player.ta.galaxyLimit) || !hasUpgrade("ta", 14))
                     {
                     if (player.ad.extraDimsGalaxiesLocked ? player.ad.dimensionAmounts[player.ad.galaxyDimCost].gte(player.ad.galaxyReq) && (player.ad.galaxyAmount.lt(1)) : player.ad.dimensionAmounts[player.ad.galaxyDimCost].gte(player.ad.galaxyReq))
                     {


### PR DESCRIPTION
Should fix the issue of not being able to autobuy DimBoosts and Galaxies, despite having bought the autobuyer for them.