### PR TITLE
Fix for extra infinities after Big Crunch

### DIFF
--- a/js/debuff.js
+++ b/js/debuff.js
@@ -434,7 +434,7 @@
             unlocked() { return true },
             onClick() {
                 player.tad.domainResetPause = new Decimal(5)
-                player.in.infinityPause = new Decimal(16)
+                player.in.infinityPause = true
                 player.de.tavPoints = player.de.tavPoints.add(player.de.tavPointsToGet)
             },
             style: { width: '400px', "min-height": '100px' },

--- a/js/dice.js
+++ b/js/dice.js
@@ -146,7 +146,7 @@
         {
             if (inChallenge("ip", 15))
             {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             }
             if (!hasChallenge("ip", 15)) player.d.currentBoosterRoll = getRandomInt(11)
             if (hasChallenge("ip", 15)) player.d.currentBoosterRoll = getRandomInt(15)
@@ -266,7 +266,7 @@
 
                 if (inChallenge("ip", 15))
                 {
-                    player.in.infinityPause = new Decimal(6)
+                    player.in.infinityPause = true
                 }
             },
             style: { width: '200px', "min-height": '100px' },

--- a/js/grass.js
+++ b/js/grass.js
@@ -86,7 +86,7 @@
             onGoldGrassMicrotab: player.subtabs.g.stuff === 'Golden Grass',
         }
 
-        const thisLayerState = (state.inGrassLayer ? 'y' : 'n')
+        const lastLayerState = (state.inGrassLayer ? 'y' : 'n')
             + (player.g.isLayerLoaded ? 'y' : 'n')
 
         // Track whether we had the layer loaded previously; the way
@@ -100,7 +100,7 @@
         //    State 5: on Grass layer (yields s && p)
         player.g.isLayerLoaded = state.inGrassLayer
 
-        player.g.lastLayerState = (state.inGrassLayer ? 'y' : 'n')
+        player.g.thisLayerState = (state.inGrassLayer ? 'y' : 'n')
             + (player.g.isLayerLoaded ? 'y' : 'n')
 
         // DEBUGGING OUTPUT
@@ -108,7 +108,7 @@
         //console.log(`Layer state: ${thisLayerState} (was ${player.g.lastLayerState})`)
 
         // Handle layer switching
-        if (player.g.lastLayerState == 'yy' && thisLayerState == 'yn') {
+        if (player.g.thisLayerState == 'yy' && lastLayerState == 'yn') {
             if (state.onGrassMicrotab) {
                 layers.g.loadGrass()
                 player.g.isGrassLoaded = true

--- a/js/grass.js
+++ b/js/grass.js
@@ -1205,13 +1205,3 @@ function createGoldGrass(quantity) {
         document.addEventListener('mousemove', checkCursorDistance);
     }
 }
-
-const logged = {}
-const logOnce = (id, str) => {
-  if (logged[id]) {
-    return
-  }
-
-  logged[id] = true
-  console.log(str)
-}

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -36,7 +36,6 @@
             player.in.reachedInfinity = true
         }
 
-        let onepersec = new Decimal(1)
         if (player.subtabs["in"]['stuff'] == 'Portal')
         {
             player.tab = "po"
@@ -443,8 +442,6 @@ addLayer("bigc", {
     tooltip: "Ranks",
     color: "white",
     update(delta) {
-        let onepersec = new Decimal(1)
-
         if (player.tab == "bigc" && !player.bigc.spawnedWisps)
         {     
             player.bigc.spawnedWisps = true

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -36,97 +36,183 @@
             player.in.reachedInfinity = true
         }
 
-        if (player.subtabs["in"]['stuff'] == 'Portal')
-        {
-            player.tab = "po"
-            player.subtabs["in"]['stuff'] = 'Features'
+        if (player.subtabs['in']['stuff'] == 'Portal') {
+            player.tab = 'po'
+            player.subtabs['in']['stuff'] = 'Features'
         }
 
-        if (player.in.infinityPoints.gt(0))
-        {
+        if (player.in.infinityPoints.gt(0)) {
             player.in.unlockedInfinity = true
         }
 
-        if (player.in.reachedInfinity && !inChallenge("ip", 11))
-        {
-            if (!player.in.breakInfinity)
-            {
-                if (inChallenge("tad", 11))
-                {
-                    if (player.bi.brokenInfinities.gt(player.tad.shatteredInfinitiesToGet) && player.po.hex && !player.po.dice && !player.po.rocketFuel && inChallenge("tad", 11) && player.tad.currentConversion.eq(0))
-                    {
-                        player.tad.shatteredInfinities = player.tad.shatteredInfinities.add(player.tad.shatteredInfinitiesToGet)
-                        player.bi.brokenInfinities = player.bi.brokenInfinities.sub(player.tad.shatteredInfinitiesToGet)
-                    }
-                    if (player.bi.brokenInfinities.gt(player.tad.disfiguredInfinitiesToGet) && !player.po.hex && !player.po.dice && player.po.rocketFuel && inChallenge("tad", 11) && player.tad.currentConversion.eq(1))
-                    {
-                        player.tad.disfiguredInfinities = player.tad.disfiguredInfinities.add(player.tad.disfiguredInfinitiesToGet)
-                        player.bi.brokenInfinities = player.bi.brokenInfinities.sub(player.tad.disfiguredInfinitiesToGet)
-                    }
-                    if (player.bi.brokenInfinities.gt(player.tad.corruptedInfinitiesToGet) && !player.po.hex && player.po.dice && !player.po.rocketFuel && inChallenge("tad", 11) && player.tad.currentConversion.eq(2))
-                    {
-                        player.tad.corruptedInfinities = player.tad.corruptedInfinities.add(player.tad.corruptedInfinitiesToGet)
-                        player.bi.brokenInfinities = player.bi.brokenInfinities.sub(player.tad.corruptedInfinitiesToGet)
-                    }
+        if (player.in.reachedInfinity
+                && !inChallenge('ip', 11)
+                && !player.in.breakInfinity
+        ) {
+            // TavDomain challenge: Tav's Domain
+            if (inChallenge('tad', 11)) {
+                const broInfGtShaInf = player.bi.brokenInfinities.gt(
+                    player.tad.shatteredInfinitiesToGet)
+                if (broInfGtShaInf
+                    && player.po.hex
+                    && !player.po.dice
+                    && !player.po.rocketFuel
+                    && player.tad.currentConversion.eq(0)
+                ) {
+                    player.tad.shatteredInfinities = player.tad.shatteredInfinities.add(player.tad.shatteredInfinitiesToGet)
+                    player.bi.brokenInfinities = player.bi.brokenInfinities.sub(player.tad.shatteredInfinitiesToGet)
                 }
-                if (!hasMilestone("ip", 21)) 
-                {
-                    player.tab = "bigc"
-                } else if (hasMilestone("ip", 21))
-                {
-                    layers.bigc.crunch()
+
+                const broInfGtDisInf = player.bi.brokenInfinities.gt(
+                    player.tad.disfiguredInfinitiesToGet)
+                if (broInfGtDisInf
+                    && !player.po.hex
+                    && !player.po.dice
+                    && player.po.rocketFuel
+                    && player.tad.currentConversion.eq(1)
+                ) {
+                    player.tad.disfiguredInfinities = player.tad.disfiguredInfinities.add(player.tad.disfiguredInfinitiesToGet)
+                    player.bi.brokenInfinities = player.bi.brokenInfinities.sub(player.tad.disfiguredInfinitiesToGet)
                 }
-                if (hasUpgrade("bi", 14))
-                {
-                    if (player.po.dice) player.om.diceMasteryPoints = player.om.diceMasteryPoints.add(player.om.diceMasteryPointsToGet)
-                    if (player.po.rocketFuel) player.om.rocketFuelMasteryPoints = player.om.rocketFuelMasteryPoints.add(player.om.rocketFuelMasteryPointsToGet)
-                    if (player.po.hex) player.om.hexMasteryPoints = player.om.hexMasteryPoints.add(player.om.hexMasteryPointsToGet)
+
+                const broInfGtCorInf = player.bi.brokenInfinities.gt(
+                    player.tad.corruptedInfinitiesToGet)
+                if (broInfGtCorInf
+                    && !player.po.hex
+                    && player.po.dice
+                    && !player.po.rocketFuel
+                    && player.tad.currentConversion.eq(2)
+                ) {
+                    player.tad.corruptedInfinities = player.tad.corruptedInfinities.add(player.tad.corruptedInfinitiesToGet)
+                    player.bi.brokenInfinities = player.bi.brokenInfinities.sub(player.tad.corruptedInfinitiesToGet)
+                }
+            }
+
+            const skipBigCrunch = hasMilestone('ip', 21)
+            if (skipBigCrunch) {
+                layers.bigc.crunch()
+            } else {
+                player.tab = 'bigc'
+            }
+
+            // BreakInfinity upgrade: BI IP Upgrade 4
+            if (hasUpgrade('bi', 14)) {
+                if (player.po.dice) {
+                    player.om.diceMasteryPoints = player.om.diceMasteryPoints
+                        .add(player.om.diceMasteryPointsToGet)
+                }
+
+                if (player.po.rocketFuel) {
+                    player.om.rocketFuelMasteryPoints = player.om.rocketFuelMasteryPoints
+                        .add(player.om.rocketFuelMasteryPointsToGet)
+                }
+
+                if (player.po.hex) {
+                    player.om.hexMasteryPoints = player.om.hexMasteryPoints
+                        .add(player.om.hexMasteryPointsToGet)
                 }
             }
         }
 
-        if (!player.in.breakInfinity) player.in.infinityPointsToGet = new Decimal(1)
-        if (player.in.breakInfinity && !hasUpgrade("bi", 111)) player.in.infinityPointsToGet = player.points.div(1e308).plus(1).log10().div(10)
-        if (player.in.breakInfinity && hasUpgrade("bi", 111)) player.in.infinityPointsToGet = player.points.div(1e308).plus(1).log10().div(2).pow(1.25)
-        if (player.in.breakInfinity && hasUpgrade("i", 31)) player.in.infinityPointsToGet = player.points.div(1e308).plus(1).log10().pow(1.5)
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("h", 21))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("h", 22))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("ip", 11))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(player.d.diceEffects[11])
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(player.rf.abilityEffects[5])
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("cb", 12))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("ta", 33))
-        if (hasUpgrade("ip", 42)) player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(upgradeEffect("ip", 42))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("f", 41))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("f", 42))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("f", 43))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("f", 44))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("f", 45))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("f", 46))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("f", 47))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("f", 48))
-        if (hasUpgrade("bi", 101)) player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(upgradeEffect("bi", 101))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(player.om.diceMasteryPointsEffect)
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("tad", 21))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("gh", 38))
-        if (hasUpgrade("bi", 23)) player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(upgradeEffect("bi", 23))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(player.ca.replicantiEffect)
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("id", 24))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("h", 23))
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(player.rm.realmModsEffect[5])
-        player.in.infinityPointsToGet = player.in.infinityPointsToGet.mul(buyableEffect("ca", 24))
-        
-        player.in.infinityPause = player.in.infinityPause.sub(1)
-        if (player.in.infinityPause.gt(0))
-        {
-            layers.in.bigCrunch();
+        // =================================================================
+        // InfinityPointsToGet logic
+
+        player.in.infinityPointsToGet = new Decimal(1)
+
+        if (player.in.breakInfinity) {
+            // BreakInfinity upgrade: BI IP Upgrade 1
+            if (hasUpgrade('bi', 111)) {
+                player.in.infinityPointsToGet = player.points
+                    .div(1e308)
+                    .plus(1)
+                    .log10()
+                    .div(2)
+                    .pow(1.25)
+            } else {
+                player.in.infinityPointsToGet = player.points
+                    .div(1e308)
+                    .plus(1)
+                    .log10()
+                    .div(10)
+            }
+
+            // Incremental (layers.js) upgrade: Challenge 1. (sic)
+            if (hasUpgrade('i', 31)) {
+                player.in.infinityPointsToGet = player.points
+                    .div(1e308)
+                    .plus(1)
+                    .log10()
+                    .pow(1.5)
+            }
         }
 
+        player.in.infinityPointsToGet = player.in.infinityPointsToGet
+            .mul(buyableEffect('h', 21))
+            .mul(buyableEffect('h', 22))
+            .mul(buyableEffect('ip', 11))
+            .mul(player.d.diceEffects[11])
+            .mul(player.rf.abilityEffects[5])
+            .mul(buyableEffect('cb', 12))
+            .mul(buyableEffect('ta', 33))
+            .mul(buyableEffect('f', 41))
+            .mul(buyableEffect('f', 42))
+            .mul(buyableEffect('f', 43))
+            .mul(buyableEffect('f', 44))
+            .mul(buyableEffect('f', 45))
+            .mul(buyableEffect('f', 46))
+            .mul(buyableEffect('f', 47))
+            .mul(buyableEffect('f', 48))
+            .mul(player.om.diceMasteryPointsEffect)
+            .mul(buyableEffect('tad', 21))
+            .mul(buyableEffect('gh', 38))
+            .mul(player.ca.replicantiEffect)
+            .mul(buyableEffect('id', 24))
+            .mul(buyableEffect('h', 23))
+            .mul(player.rm.realmModsEffect[5])
+            .mul(buyableEffect('ca', 24))
+
+        // InfinityPoints upgrade: Upgrade (4, 2)
+        if (hasUpgrade('ip', 42)) {
+            player.in.infinityPointsToGet = player.in.infinityPointsToGet
+                .mul(upgradeEffect('ip', 42))
+        }
+
+        // BreakInfinity upgrade: BI UP Upgrade 7
+        if (hasUpgrade('bi', 23)) {
+            player.in.infinityPointsToGet = player.in.infinityPointsToGet
+                .mul(upgradeEffect('bi', 23))
+        }
+        
+        // BreakInfinity upgrade: BI NIP Upgrade 1
+        if (hasUpgrade('bi', 101)) {
+            player.in.infinityPointsToGet = player.in.infinityPointsToGet
+                .mul(upgradeEffect('bi', 101))
+        }
+
+        // DEBUGGING OUTPUT
+        //logOnce('iptg', `infinityPointsToGet:${player.in.infinityPointsToGet}`)
+
+        // =================================================================
+        // InfinitiesToGet logic
+
         player.in.infinitiesToGet = new Decimal(1)
-        player.in.infinitiesToGet = player.in.infinitiesToGet.mul(buyableEffect("bi", 11))
-        player.in.infinitiesToGet = player.in.infinitiesToGet.mul(buyableEffect("tad", 11))
-        player.in.infinitiesToGet = player.in.infinitiesToGet.mul(buyableEffect("om", 11))
-        player.in.infinitiesToGet = player.in.infinitiesToGet.mul(buyableEffect("p", 15))
+            .mul(buyableEffect('bi', 11))
+            .mul(buyableEffect('tad', 11))
+            .mul(buyableEffect('om', 11))
+            .mul(buyableEffect('p', 15))
+
+        // =================================================================
+        // Multi-reset logic
+
+        //console.log(`[update] iptg:${player.in.infinityPointsToGet}, itg:${player.in.infinitiesToGet}`)
+
+        // player.in.infinityPause gets set to 5 in crunch()
+        // XXX: reset 5 times in a row, or it doesn't reset "properly"
+        // TODO: recreate an improper reset to see what that looks like
+        player.in.infinityPause = player.in.infinityPause.sub(1)
+        if (player.in.infinityPause.gt(0)) {
+            layers.in.bigCrunch();
+        }
     },
     bigCrunch()
     {

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -214,9 +214,12 @@
             layers.in.bigCrunch();
         }
     },
-    bigCrunch()
-    {
+    bigCrunch() {
         player.points = new Decimal(10)
+
+        // =================================================================
+        // Rank
+
         player.r.rank = new Decimal(0)
         player.r.tier = new Decimal(0)
         player.r.tetr = new Decimal(0)
@@ -226,99 +229,70 @@
         player.r.pentToGet = new Decimal(0)
         player.r.pent = new Decimal(0)
 
-        player.f.factorUnlocks = [true, true, true, false, false, false, false, false]
+        // InfinityPoints milestone, 6 Infinities
+        // InfinityPoints challenge, Challenge 4
+        if (!hasMilestone('ip', 15) && !inChallenge('ip', 14)) {
+            player.r.milestones = player.r.milestones
+                .filter((o) => (+o) >= 20)
+        }
+
+        // =================================================================
+        // Factor
+
+        player.f.factorUnlocks = [
+            true, true, true, false,
+            false, false, false, false
+        ]
         player.f.factorGain = new Decimal(1)
 
         player.f.factorPower = new Decimal(0)
         player.f.factorPowerEffect = new Decimal(1)
         player.f.factorPowerPerSecond = new Decimal(0)
-        player.f.powerFactorUnlocks = [true, true, true, false, false, false, false, false]
+        player.f.powerFactorUnlocks = [
+            true, true, true, false,
+            false, false, false, false
+        ]
 
-        player.f.buyables[1] = new Decimal(0)
-        player.f.buyables[2] = new Decimal(0)
-        player.f.buyables[3] = new Decimal(0)
-        player.f.buyables[4] = new Decimal(0)
-        player.f.buyables[5] = new Decimal(0)
-        player.f.buyables[6] = new Decimal(0)
-        player.f.buyables[7] = new Decimal(0)
-        player.f.buyables[8] = new Decimal(0)
-        player.f.buyables[11] = new Decimal(0)
-        player.f.buyables[12] = new Decimal(0)
-        player.f.buyables[13] = new Decimal(0)
-        player.f.buyables[14] = new Decimal(0)
-        player.f.buyables[15] = new Decimal(0)
-        player.f.buyables[16] = new Decimal(0)
-        player.f.buyables[17] = new Decimal(0)
-        player.f.buyables[18] = new Decimal(0)
-        player.f.buyables[19] = new Decimal(0)
-        player.f.buyables[21] = new Decimal(0)
-        player.f.buyables[22] = new Decimal(0)
-        player.f.buyables[23] = new Decimal(0)
-        player.f.buyables[24] = new Decimal(0)
-        player.f.buyables[25] = new Decimal(0)
-        player.f.buyables[26] = new Decimal(0)
-        player.f.buyables[27] = new Decimal(0)
-        player.f.buyables[28] = new Decimal(0)
-        player.f.buyables[29] = new Decimal(0)
-        player.f.buyables[31] = new Decimal(0)
-        player.f.buyables[32] = new Decimal(0)
-        player.f.buyables[33] = new Decimal(0)
-        player.f.buyables[34] = new Decimal(0)
-        player.f.buyables[35] = new Decimal(0)
-        player.f.buyables[36] = new Decimal(0)
+        for (let i = 1; i <= 36; ++i) {
+            player.f.buyables[i] = new Decimal(0)
+        }
+
+        // =================================================================
+        // Prestige
 
         player.p.prestigePoints = new Decimal(0)
 
-        if (!hasMilestone("ip", 11) && !inChallenge("ip", 14)) {
-            for (let i = 0; i < player.p.upgrades.length; i++) {
-                if (+player.p.upgrades[i] < 24) {
-                    player.p.upgrades.splice(i, 1);
-                    i--;
-                }
-            }
+        // InfinityPoints milestone, 2 Infinities
+        // InfinityPoints challenga, Challenge 4
+        if (!hasMilestone('ip', 11) && !inChallenge('ip', 14)) {
+            player.p.upgrades = player.p.upgrades
+                .filter((o) => (+o) >= 24)
         }
 
-        player.t.buyables[11] = new Decimal(0)
-        player.t.buyables[12] = new Decimal(0)
-        player.t.buyables[13] = new Decimal(0)
-        player.t.buyables[14] = new Decimal(0)
-        player.t.buyables[15] = new Decimal(0)
-        player.t.buyables[16] = new Decimal(0)
-        player.t.buyables[17] = new Decimal(0)
-        player.t.buyables[18] = new Decimal(0)
+        // =================================================================
+        // Trees
+
+        for (let i = 11; i <= 18; ++i) {
+            player.t.buyables[i] = new Decimal(0)
+        }
 
         player.f.factorPower = new Decimal(0)
 
         player.t.leaves = new Decimal(0)
         player.t.trees = new Decimal(0)
 
-        player.g.buyables[11] = new Decimal(0)
-        player.g.buyables[12] = new Decimal(0)
-        player.g.buyables[13] = new Decimal(0)
-        player.g.buyables[14] = new Decimal(0)
-        player.g.buyables[15] = new Decimal(0)
-        player.g.buyables[16] = new Decimal(0)
-        player.g.buyables[17] = new Decimal(0)
-        player.g.buyables[18] = new Decimal(0)
+        // =================================================================
+        // Grass
 
-        if (!hasMilestone("ip", 11) && !inChallenge("ip", 14))
-        {
-        for (let i = 0; i < player.g.upgrades.length; i++) {
-            if (+player.g.upgrades[i] < 22) {
-                player.g.upgrades.splice(i, 1);
-                i--;
-            }
-        }
+        for (let i = 11; i <= 18; ++i) {
+            player.g.buyables[i] = new Decimal(0)
         }
 
-        if (!hasMilestone("ip", 15) && !inChallenge("ip", 14))
-        {
-            for (let i = 0; i < player.r.milestones.length; i++) {
-                if (+player.r.milestones[i] < 20) {
-                    player.r.milestones.splice(i, 1);
-                    i--;
-                }
-            }
+        // InfinityPoints milestone, 2 Infinities
+        // InfinityPoints challenge, Challenge 4
+        if (!hasMilestone('ip', 11) && !inChallenge('ip', 14)) {
+            player.g.upgrades = player.g.upgrades
+                .filter((o) => (+o) >= 22)
         }
 
         player.g.grass = new Decimal(0)
@@ -331,73 +305,94 @@
         player.g.goldGrassCount = new Decimal(0)
         player.g.goldGrassTimer = new Decimal(0)
 
+        // =================================================================
+        // Grasshop
+
         player.gh.grasshoppers = new Decimal(0)
         player.gh.fertilizer = new Decimal(0)
 
-        player.gh.buyables[11] = new Decimal(0)
-        player.gh.buyables[12] = new Decimal(0)
-        player.gh.buyables[13] = new Decimal(0)
-        player.gh.buyables[14] = new Decimal(0)
-        player.gh.buyables[15] = new Decimal(0)
-        player.gh.buyables[16] = new Decimal(0)
-        player.gh.buyables[17] = new Decimal(0)
-        player.gh.buyables[18] = new Decimal(0)
-        player.gh.buyables[19] = new Decimal(0)
-        player.gh.buyables[21] = new Decimal(0)
-        player.gh.buyables[22] = new Decimal(0)
+        for (let i = 11; i <= 22; ++i) {
+            // There is no 20
+            if (i === 20) {
+                continue
+            }
+
+            player.gh.buyables[i] = new Decimal(0)
+        }
+
+        // =================================================================
+        // Mods
 
         player.m.codeExperience = new Decimal(0)
         player.m.linesOfCode = new Decimal(0)
         player.m.mods = new Decimal(0)
 
-        player.m.buyables[11] = new Decimal(0)
-        player.m.buyables[12] = new Decimal(0)
-        player.m.buyables[13] = new Decimal(0)
-        player.m.buyables[14] = new Decimal(0)
+        for (let i = 11; i <= 14; ++i) {
+            player.m.buyables[i] = new Decimal(0)
+        }
 
-        //dice
+        // =================================================================
+        // Dice
+
         player.d.dicePoints = new Decimal(0)
         player.d.diceRolls = [new Decimal(1)] 
         player.d.dice = new Decimal(1)
 
-        player.d.buyables[11] = new Decimal(0)
-        player.d.buyables[12] = new Decimal(0)
-        player.d.buyables[13] = new Decimal(0)
-        player.d.buyables[14] = new Decimal(0)
-        player.d.buyables[15] = new Decimal(0)
+        for (let i = 11; i <= 15; ++i) {
+            player.d.buyables[i] = new Decimal(0)
+        }
 
-        for (let i = 0; i < 11; i++)
-        {
+        for (let i = 0; i < 11; i++) {
             player.d.diceEffects[i] = new Decimal(1)
         }
 
-        //rf
+        if (!inChallenge("ip", 15)) {
+          player.d.challengeDicePoints = new Decimal(0)
+          for (let i = 21; i <= 24; ++i) {
+              player.d.buyables[i] = new Decimal(0)
+          }
+
+          for (let i = 0; i < player.d.upgrades.length; i++) {
+              player.d.upgrades = player.d.upgrades
+                  .filter((o) => (+o) >= 100)
+          }
+        }
+
+        // =================================================================
+        // Rocket fuel
+
         player.rf.rocketFuel = new Decimal(0)
-        for (let i = 0; i < player.rf.abilitiesUnlocked.length; i++)
-        {
+        for (let i = 0; i < player.rf.abilitiesUnlocked.length; i++) {
             player.rf.abilitiesUnlocked[i] = false
         }
-        for (let i = 0; i < 4; i++)
-        {
+        for (let i = 0; i < 4; i++) {
             player.rf.abilityTimers[i] = new Decimal(0)
         }
 
         for (let i = 0; i < player.rf.upgrades.length; i++) {
-            if (+player.rf.upgrades[i] < 18) {
-                player.rf.upgrades.splice(i, 1);
-                i--;
-            }
+            player.rf.upgrades = player.rf.upgrades
+                .filter((o) => (+o) >= 18)
         }
+
+        // =================================================================
+        // Infinity
 
         for (let i = 0; i < player.i.upgrades.length; i++) {
-            if (+player.i.upgrades[i] < 22) {
-                player.i.upgrades.splice(i, 1);
-                i--;
-            }
+            player.i.upgrades = player.i.upgrades
+                .filter((o) => (+o) >= 22)
         }
 
-        if (!player.po.keepOTFS || inChallenge("ip", 15) || inChallenge("ip", 16))
-        {
+        // =================================================================
+        // Portal
+
+        // Portal, keep OTFs on reset
+        // InfinityPoints challenge, Challenge 5
+        // InfinityPoints challenge, Challenge 6
+        if (
+            !player.po.keepOTFS
+            || inChallenge('ip', 15)
+            || inChallenge('ip', 16)
+        ) {
             player.po.dice = false
             player.po.rocketFuel = false
             player.po.hex = false
@@ -406,49 +401,36 @@
             player.po.featureSlots = player.po.featureSlotsMax
         }
         
+        // =================================================================
+        // Antimatter Dimensions
 
-        //reset antimatter stuff
-
-        if (!hasMilestone("ip", 14))
-        {
-            if (player.in.infinities.eq(0)) player.ad.antimatter = new Decimal(10)
+        if (!hasMilestone('ip', 14)) {
+            if (player.in.infinities.lt(1)) {
+                player.ad.antimatter = new Decimal(10)
+            }
 
             player.ad.buyables[1] = new Decimal(0)
     
-            for (let i = 0; i < player.ad.dimensionAmounts.length; i++)
-            {
+            for (let i = 0; i < player.ad.dimensionAmounts.length; i++) {
                 player.ad.dimensionAmounts[i] = new Decimal(0)
                 player.ad.dimensionsPurchased[i] = new Decimal(0)
             }
     
-            player.ad.dimensionsUnlocked[4] = false
-            player.ad.dimensionsUnlocked[5] = false
-            player.ad.dimensionsUnlocked[6] = false
-            player.ad.dimensionsUnlocked[7] = false
+            for (let i = 4; i <= 7; ++i) {
+                player.ad.dimensionsUnlocked[i] = false
+            }
             
             player.ad.dimBoostAmount = new Decimal(0)
             player.ad.galaxyAmount = new Decimal(0)
         }
 
-        //challenge stuff
+        // =================================================================
+        // Pests
+
         player.pe.pests = new Decimal(0)
 
-        if (!inChallenge("ip", 15))
-        {
-        
-        player.d.challengeDicePoints = new Decimal(0)
-        player.d.buyables[21] = new Decimal(0)
-        player.d.buyables[22] = new Decimal(0)
-        player.d.buyables[23] = new Decimal(0)
-        player.d.buyables[24] = new Decimal(0)
-
-        for (let i = 0; i < player.d.upgrades.length; i++) {
-            if (+player.d.upgrades[i] < 100) {
-                player.d.upgrades.splice(i, 1);
-                i--;
-            }
-        }
-        }
+        // =================================================================
+        // Debuff
 
         player.de.antidebuffPoints = new Decimal(0)
     },

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -1,5 +1,4 @@
-﻿var tree = [["ad", "ip", "id"], ["ga", "ta", "bi", "om"], ["ca"]]
-addLayer("in", {
+﻿addLayer("in", {
     name: "Universe 2", // This is optional, only used in a few places, If absent it just uses the layer id.
     symbol: "2", // This appears on the layer's node. Default is the id with the first letter capitalized
     row: 1,
@@ -401,7 +400,11 @@ addLayer("in", {
                 content:
                 [
                         ["blank", "25px"],
-                        ["tree", tree],
+                        ["tree", [
+                            ["ad", "ip", "id"],
+                            ["ga", "ta", "bi", "om"],
+                            ["ca"]
+                        ]]
                 ]
 
             },

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -33,6 +33,9 @@ addLayer("in", {
     color: "white",
     branches: ["i"],
     update(delta) {
+        if (player.points.gte(Number.MAX_VALUE)) {
+            player.in.reachedInfinity = true
+        }
 
         let onepersec = new Decimal(1)
         if (player.subtabs["in"]['stuff'] == 'Portal')

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -32,9 +32,6 @@
     color: "white",
     branches: ["i"],
     update(delta) {
-        // DEBUGGING OUTPUT
-        //logOnce('infUpdateTop', `[infUpdateTop] player.points:${player.points}`)
-
         // =================================================================
         // Miscellaneous logic
 
@@ -191,18 +188,12 @@
                 .mul(upgradeEffect('bi', 101))
         }
 
-        // DEBUGGING OUTPUT
-        //logOnce('iptg', `infinityPointsToGet:${player.in.infinityPointsToGet}`)
-
         // bigCrunch ASAP, since we don't need player.points after this point
         if (player.points.gte(Number.MAX_VALUE)) {
             player.in.reachedInfinity = true
 
             // N.B. try doing bigCrunch as soon as we can
             layers.in.bigCrunch();
-
-            // DEBUGGING OUTPUT
-            //console.log(`player.points:${player.points}`)
         }
 
 
@@ -219,10 +210,7 @@
         // Multi-reset logic
 
         if (player.in.infinityPause) {
-            // DEBUGGING OUTPUT
-            //console.log(`[update] bi:${buyableEffect('bi', 11)}, tad:${buyableEffect('tad', 11)}, om:${buyableEffect('om', 11)}, p:${buyableEffect('p', 15)}`)
-            //console.log(`[update] iptg:${player.in.infinityPointsToGet}, itg:${player.in.infinitiesToGet}`)
-
+            // XXX: this may not be needed anymore; further testing required!
             //layers.in.bigCrunch();
             player.in.infinityPause = false
         }
@@ -543,8 +531,6 @@ addLayer("bigc", {
             onClick() {
                 player.tab = "in"
 
-                // DEBUGGING OUTPUT
-                //console.log('clicked BigCrunch')
                 layers.bigc.crunch()
             },
             style: { width: '300px', "min-height": '120px' },
@@ -552,9 +538,6 @@ addLayer("bigc", {
         
     },
     crunch(){
-        // DEBUGGING OUTPUT
-        //console.log(`[crunch] iptg:${player.in.infinityPointsToGet}, itg:${player.in.infinitiesToGet}`)
-
         player.in.infinityPoints = player.in.infinityPoints
             .add(player.in.infinityPointsToGet)
         player.in.infinityPointsToGet = new Decimal(0)
@@ -562,9 +545,6 @@ addLayer("bigc", {
         player.in.infinities = player.in.infinities
             .add(player.in.infinitiesToGet)
         player.in.infinitiesToGet = new Decimal(0)
-
-        // DEBUGGING OUTPUT
-        //console.log(`[crunch2] iptg:${player.in.infinityPointsToGet}, itg:${player.in.infinitiesToGet}`)
 
         if (player.po.dice)
         {

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -12,7 +12,7 @@
 
         infinityPoints: new Decimal(0),
         infinityPointsToGet: new Decimal(0),
-        infinityPause: new Decimal(0),
+        infinityPause: false,
 
         infinities: new Decimal(0),
         infinitiesToGet: new Decimal(1),
@@ -204,14 +204,12 @@
         // =================================================================
         // Multi-reset logic
 
-        //console.log(`[update] iptg:${player.in.infinityPointsToGet}, itg:${player.in.infinitiesToGet}`)
+        if (player.in.infinityPause) {
+            // DEBUGGING OUTPUT
+            //console.log(`[update] iptg:${player.in.infinityPointsToGet}, itg:${player.in.infinitiesToGet}`)
 
-        // player.in.infinityPause gets set to 5 in crunch()
-        // XXX: reset 5 times in a row, or it doesn't reset "properly"
-        // TODO: recreate an improper reset to see what that looks like
-        player.in.infinityPause = player.in.infinityPause.sub(1)
-        if (player.in.infinityPause.gt(0)) {
             layers.in.bigCrunch();
+            player.in.infinityPause = false
         }
     },
     bigCrunch() {
@@ -534,8 +532,17 @@ addLayer("bigc", {
         
     },
     crunch(){
-        player.in.infinityPoints = player.in.infinityPoints.add(player.in.infinityPointsToGet)
-        player.in.infinities = player.in.infinities.add(player.in.infinitiesToGet)
+        // DEBUGGING OUTPUT
+        //console.log(`[crunch] iptg:${player.in.infinityPointsToGet}, itg:${player.in.infinitiesToGet}`)
+
+        player.in.infinityPoints = player.in.infinityPoints
+            .add(player.in.infinityPointsToGet)
+        player.in.infinityPointsToGet = new Decimal(0)
+
+        player.in.infinities = player.in.infinities
+            .add(player.in.infinitiesToGet)
+        player.in.infinitiesToGet = new Decimal(0)
+
         if (player.po.dice)
         {
             player.ip.diceRuns = player.ip.diceRuns.add(1)
@@ -548,7 +555,7 @@ addLayer("bigc", {
         {
             player.ip.hexRuns = player.ip.hexRuns.add(1)
         }
-        player.in.infinityPause = new Decimal(5)
+        player.in.infinityPause = true
         player.in.reachedInfinity = false
 
         if (inChallenge("ip", 11))

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -32,9 +32,11 @@
     color: "white",
     branches: ["i"],
     update(delta) {
-        if (player.points.gte(Number.MAX_VALUE)) {
-            player.in.reachedInfinity = true
-        }
+        // DEBUGGING OUTPUT
+        //logOnce('infUpdateTop', `[infUpdateTop] player.points:${player.points}`)
+
+        // =================================================================
+        // Miscellaneous logic
 
         if (player.subtabs['in']['stuff'] == 'Portal') {
             player.tab = 'po'
@@ -192,6 +194,18 @@
         // DEBUGGING OUTPUT
         //logOnce('iptg', `infinityPointsToGet:${player.in.infinityPointsToGet}`)
 
+        // bigCrunch ASAP, since we don't need player.points after this point
+        if (player.points.gte(Number.MAX_VALUE)) {
+            player.in.reachedInfinity = true
+
+            // N.B. try doing bigCrunch as soon as we can
+            layers.in.bigCrunch();
+
+            // DEBUGGING OUTPUT
+            //console.log(`player.points:${player.points}`)
+        }
+
+
         // =================================================================
         // InfinitiesToGet logic
 
@@ -206,15 +220,14 @@
 
         if (player.in.infinityPause) {
             // DEBUGGING OUTPUT
+            //console.log(`[update] bi:${buyableEffect('bi', 11)}, tad:${buyableEffect('tad', 11)}, om:${buyableEffect('om', 11)}, p:${buyableEffect('p', 15)}`)
             //console.log(`[update] iptg:${player.in.infinityPointsToGet}, itg:${player.in.infinitiesToGet}`)
 
-            layers.in.bigCrunch();
+            //layers.in.bigCrunch();
             player.in.infinityPause = false
         }
     },
     bigCrunch() {
-        player.points = new Decimal(10)
-
         // =================================================================
         // Rank
 
@@ -431,6 +444,11 @@
         // Debuff
 
         player.de.antidebuffPoints = new Decimal(0)
+
+        // =================================================================
+        // Core
+
+        player.points = new Decimal(10)
     },
     branches: ["branch"],
     clickables: {
@@ -525,6 +543,8 @@ addLayer("bigc", {
             onClick() {
                 player.tab = "in"
 
+                // DEBUGGING OUTPUT
+                //console.log('clicked BigCrunch')
                 layers.bigc.crunch()
             },
             style: { width: '300px', "min-height": '120px' },
@@ -542,6 +562,9 @@ addLayer("bigc", {
         player.in.infinities = player.in.infinities
             .add(player.in.infinitiesToGet)
         player.in.infinitiesToGet = new Decimal(0)
+
+        // DEBUGGING OUTPUT
+        //console.log(`[crunch2] iptg:${player.in.infinityPointsToGet}, itg:${player.in.infinitiesToGet}`)
 
         if (player.po.dice)
         {

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -183,15 +183,14 @@
 
         player.p.prestigePoints = new Decimal(0)
 
-        if (!hasMilestone("ip", 11) && !inChallenge("ip", 14))
-        {
-        for (let i = 0; i < player.p.upgrades.length; i++) {
-            if (+player.p.upgrades[i] < 24) {
-                player.p.upgrades.splice(i, 1);
-                i--;
+        if (!hasMilestone("ip", 11) && !inChallenge("ip", 14)) {
+            for (let i = 0; i < player.p.upgrades.length; i++) {
+                if (+player.p.upgrades[i] < 24) {
+                    player.p.upgrades.splice(i, 1);
+                    i--;
+                }
             }
         }
-    }
 
         player.t.buyables[11] = new Decimal(0)
         player.t.buyables[12] = new Decimal(0)
@@ -423,8 +422,9 @@
          ["raw-html", function () { return "You are gaining <h3>" + format(player.ad.antimatterPerSecond) + "</h3> antimatter per second." }, { "color": "white", "font-size": "16px", "font-family": "monospace" }],
                         ["microtabs", "stuff", { 'border-width': '0px' }],
         ],
-    layerShown() { return player.startedGame == true && player.in.unlockedInfinity}
+    layerShown: () => player.startedGame && player.in.unlockedInfinity
 })
+
 addLayer("bigc", {
     name: "Big Crunch", // This is optional, only used in a few places, If absent it just uses the layer id.
     symbol: "BC", // This appears on the layer's node. Default is the id with the first letter capitalized

--- a/js/infinityPoints.js
+++ b/js/infinityPoints.js
@@ -546,10 +546,10 @@
             canComplete: function () { return player.points.gte(1.79e308) },
             rewardDescription: "Unlock new grass studies.",
             onEnter() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             onExit() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             style: { width: '350px', height: '275px', }
 
@@ -562,10 +562,10 @@
             rewardDescription: "Unlocks a new check back button at level 125.",
             unlocked() { return hasChallenge("ip", 11) },
             onEnter() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             onExit() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             style: { width: '350px', height: '275px', }
 
@@ -579,10 +579,10 @@
             rewardDescription: "Permanently unlocks hex as an otherworldly feature.",
             unlocked() { return hasChallenge("ip", 12) },
             onEnter() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             onExit() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             style: { width: '350px', height: '275px', }
 
@@ -596,10 +596,10 @@
             rewardDescription: "Unlocks infinity point buyables and new milestones.",
             unlocked() { return hasChallenge("ip", 13) },
             onEnter() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             onExit() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             style: { width: '350px', height: '275px', }
 
@@ -613,7 +613,7 @@
             rewardDescription: "Unlock new booster dice effects, and booster dice automation.",
             unlocked() { return hasChallenge("ip", 14) },
             onEnter() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
 
                 player.d.challengeDicePoints = new Decimal(0)
                 player.d.buyables[21] = new Decimal(0)
@@ -629,7 +629,7 @@
                 }
             },
             onExit() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             style: { width: '350px', height: '275px', }
 
@@ -643,10 +643,10 @@
             rewardDescription: "Unlock new rocket fuel abilities, and ability automation, and gain 20% of rocket fuel per second.",
             unlocked() { return hasChallenge("ip", 15) },
             onEnter() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             onExit() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             style: { width: '350px', height: '275px', }
 
@@ -660,13 +660,13 @@
             rewardDescription: "Check back buyables.",
             unlocked() { return hasChallenge("ip", 16) },
             onEnter() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
 
                 player.cb.level = new Decimal(1)
                 player.cb.xp = new Decimal(0)
             },
             onExit() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             style: { width: '350px', height: '275px', }
 
@@ -680,10 +680,10 @@
             rewardDescription: "....???",
             unlocked() { return hasChallenge("ip", 17) },
             onEnter() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             onExit() {
-                player.in.infinityPause = new Decimal(6)
+                player.in.infinityPause = true
             },
             style: { width: '350px', height: '275px', }
 

--- a/js/portal.js
+++ b/js/portal.js
@@ -30,11 +30,6 @@ addLayer("po", {
     update(delta) {
         let onepersec = new Decimal(1)
 
-        if (player.points.gte(Number.MAX_VALUE))
-        {
-            player.in.reachedInfinity = true
-        }
-
         if (player.po.pointHaltInput.gte(1)) 
         {
             if (player.po.pointHaltInput.neq(player.po.pointHalt))

--- a/js/portal.js
+++ b/js/portal.js
@@ -229,7 +229,7 @@ addLayer("po", {
             canClick() { return player.po.featureSlots.gte(2) && player.ca.replicanti.gte(1.79e308) && player.ca.canteCores.gte(1)},
             unlocked() { return hasUpgrade("bi", 27) },
             onClick() { 
-                player.in.infinityPause = new Decimal(8)
+                player.in.infinityPause = true
                 player.po.keepOTFS = true
                 player.po.realmMods = true
                 player.ca.canteCores = player.ca.canteCores.sub(1)

--- a/js/tavDomain.js
+++ b/js/tavDomain.js
@@ -579,11 +579,11 @@
             unlocked() { return true },
             onEnter() {
                 player.tad.domainResetPause = new Decimal(5)
-                player.in.infinityPause = new Decimal(16)
+                player.in.infinityPause = true
             },
             onExit() {
                 player.tad.domainResetPause = new Decimal(5)
-                player.in.infinityPause = new Decimal(16)
+                player.in.infinityPause = true
 
                 player.po.hex = false
                 player.po.dice = false

--- a/js/utils.js
+++ b/js/utils.js
@@ -410,3 +410,16 @@ function gridRun(layer, func, data, id) {
 	else
 		return layers[layer].grid[func];
 }
+
+// ============================================================
+// Debugging
+
+const logged = {}
+const logOnce = (id, str) => {
+  if (logged[id]) {
+    return
+  }
+
+  logged[id] = true
+  console.log(str)
+}


### PR DESCRIPTION
Achieving an infinity (i.e. points >= 1e308) normally takes the player to the Big Crunch, where the user can press the Big Crunch button and end up at the Portal.  The existing code can award multiple infinity points, which can wreak havoc on games (e.g. the player can get a soft-lock if they get 2 infinity points on their first infinity, then elect to get `Upgrade (1, 2)`: this leaves the player without a way to get `Upgrade (1, 1)`).

This fix changes the logic by which infinity points are awarded: instead of using a multiple-overwrite method to ensure data is reset, the new logic overwrites once, but ensures that in-queue awarded points are immediately zeroed out after being awarded.  Limited local testing reveals that this is sufficient to prevent the game from awarding multiple infinities, but more in-depth testing from people who have ready access to Tav's Domain and Debuff is indicated to validate functionality in those layers.

[This save](https://github.com/user-attachments/files/17357232/celestial-incremental--bigcrunch--multi-infinity-points--save--20241013.txt), when imported, will take the user to a Big Crunch immediately after the 2nd infinity has been achieved.  This save data can be used for the following testing flow:

**Replication**
- Open Celestial Incremental
- Settings
- Import
- Paste in contents of save file
- Game should load to Big Crunch button
- Press Big Crunch

**Expected**: "Milestone Gotten: 2 Infinities" then you transition to the Infinity layer (i.e. black background, AD and infinity buttons)

**Actual**: most of the time, "Milestone Gotten: 2 Infinities", followed by a transition back to another Big Crunch button; pushing Big Crunch again will result in "Milestone Gotten: 3 Infinities", followed by a transition to the Infinity layer

After applying the PR, the expected behavior should occur 100% of the time.