### PR TITLE
Adds a check for breakInfinity when going >1e308

### DIFF
--- a/js/infinity.js
+++ b/js/infinity.js
@@ -189,7 +189,7 @@
         }
 
         // bigCrunch ASAP, since we don't need player.points after this point
-        if (player.points.gte(Number.MAX_VALUE)) {
+        if (player.points.gte(Number.MAX_VALUE) && !player.in.breakInfinity) {
             player.in.reachedInfinity = true
 
             // N.B. try doing bigCrunch as soon as we can


### PR DESCRIPTION
[PR 7 (Fix for extra infinities after Big Crunch)](https://github.com/Icecreamdudes/celestial_incremental/pull/7) fixed the multiple infinities glitch, at the cost of breaking the Breaking Infinity code.

This one-liner accounts for the state of `player.in.breakInfinity` and allows:
- Hitting the infinity limit if Break Infinity isn't active
- Allowing points to grow past 1e308 if Break Infinity _is_ active

Tested on:
- A save before Break Infinity, prior to achieving >1e308 (I verified that the Big Crunch screen properly appears when points grow past 1e308)
- A save after Break Infinity, with points >1e308