### PR TITLE
Multiple bug fixes relating to evos and dice.

### DIFF
--- a/js/dice.js
+++ b/js/dice.js
@@ -269,6 +269,8 @@
                 {
                     player.in.infinityPause = new Decimal(5)
                 }
+                
+                if (player.ev.evolutionsUnlocked[5]) player.d.challengeDicePoints = player.d.challengeDicePoints.add(player.d.challengeDicePointsToGet)
             },
             style: { width: '200px', "min-height": '100px' },
         },

--- a/js/evolution.js
+++ b/js/evolution.js
@@ -277,7 +277,7 @@
         },
         23: {
             title() { return "EVOLVE" },
-            canClick() { return player.cb.evolutionShards.gte(25) && player.cb.paragonShards.gte(1) && player.d.dicePoints.gte(1e45) && player.cb.evolvedLevels[0].gte(6) && player.cb.evolvedLevels[1].gte(6) && player.cb.evolvedLevels[2].gte(5) && player.cb.XPBoost.gte(7) && player.cb.rarePetLevels[1].gte(5) },
+            canClick() { return player.cb.evolutionShards.gte(25) && player.cb.paragonShards.gte(1) && player.ta.highestDicePoints.gte(1e45) && player.cb.evolvedLevels[0].gte(6) && player.cb.evolvedLevels[1].gte(6) && player.cb.evolvedLevels[2].gte(5) && player.cb.XPBoost.gte(7) && player.cb.rarePetLevels[1].gte(5) },
             unlocked() { return player.ev.evolutionDisplayIndex == 5 },
             onClick() {
                 player.ev.evolutionDisplayIndex = new Decimal(-1)
@@ -1477,14 +1477,14 @@ addLayer("ev4", {
                 let growth = 1.2
                 if (player.buyMax == false)
                 {
-                    let buyonecost = new Decimal(growth).pow(getBuyableAmount(this.layer, this.id)).mul(base)
+                    let buyonecost = new Decimal(growth).pow(getBuyableAmount(this.layer, this.id)).mul(base).floor()
                     player.cb.evolutionShards = player.cb.evolutionShards.sub(buyonecost)
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
     
                 let max = Decimal.affordGeometricSeries(player.cb.evolutionShards, base, growth, getBuyableAmount(this.layer, this.id))
-                let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
+                let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id)).floor()
                 player.cb.evolutionShards = player.cb.evolutionShards.sub(cost)
 
                 setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))

--- a/js/hex.js
+++ b/js/hex.js
@@ -382,7 +382,7 @@
         player.d.buyables[14] = new Decimal(0)
         player.d.buyables[15] = new Decimal(0)
 
-        for (let i = 0; i < player.d.diceEffects.length; i++)
+        for (let i = 0; i < 11; i++)
         {
             player.d.diceEffects[i] = new Decimal(1)
         }
@@ -565,7 +565,7 @@
         player.d.buyables[14] = new Decimal(0)
         player.d.buyables[15] = new Decimal(0)
 
-        for (let i = 0; i < player.d.diceEffects.length; i++)
+        for (let i = 0; i < 11; i++)
         {
             player.d.diceEffects[i] = new Decimal(1)
         }

--- a/js/realmMods.js
+++ b/js/realmMods.js
@@ -300,7 +300,7 @@
         player.d.buyables[14] = new Decimal(0)
         player.d.buyables[15] = new Decimal(0)
 
-        for (let i = 0; i < player.d.diceEffects.length; i++)
+        for (let i = 0; i < 11; i++)
         {
             player.d.diceEffects[i] = new Decimal(1)
         }


### PR DESCRIPTION
Fixed Manual Booster Dice not giving challenge points if you have d20 evo. Fixed hex/rage/blank mod reset accidentally resetting the last 4 dice effects. Fixed Star evo buyables cost not being floored. Fixed buying dice evo checking for current dice points instead of highest.