### PR TITLE
Grass refactor: microtabs, loading, spawnArea rendering

### DIFF
--- a/js/grass.js
+++ b/js/grass.js
@@ -985,106 +985,350 @@
     microtabs: {
         stuff: {
             'Grass': {
-                buttonStyle() { return { 'color': 'white' } },
-                unlocked() { return true },
-                content:
-                [
-                        ["blank", "25px"],
-                        ["raw-html", function () { return "<h3>" + formatWhole(player.g.grassCount) + "/" + formatWhole(player.g.grassCap) + " Grass (Hover over the grass)" }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                        ["raw-html", function () { return "<h3>" + format(player.g.grassTimer) + "/" + format(player.g.grassReq) + " Seconds to spawn grass." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                        ["raw-html", function () { return "<div id=spawn-area class=spawn-area></div>" }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                        ["blank", "600px"],
-            ]
+                buttonStyle: {
+                    'color': 'white',
+                },
+                unlocked: true,
+                content: [
+                    ['blank', '25px'],
+                    ['raw-html', () =>
+                        '<h3>' + formatWhole(player.g.grassCount) +
+                            '/' + formatWhole(player.g.grassCap) +
+                            ' Grass (Hover over the grass)',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        }
+                    ],
+                    ['raw-html', () =>
+                        '<h3>' + format(player.g.grassTimer) +
+                            '/' + format(player.g.grassReq) +
+                            ' Seconds to spawn grass.',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        }
+                    ],
+                    ['raw-html', () =>
+                        '<div id=spawn-area class=spawn-area></div>',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        }
+                    ],
+                    ['blank', '600px'],
+                ],
             },
             'Golden Grass': {
-                buttonStyle() { return { 'color': 'white' } },
-                unlocked() { return hasUpgrade("g", 13) },
-                content:
-                [
-                    ["blank", "25px"],
-                    ["raw-html", function () { return "You have <h3>" + format(player.g.goldGrass) + "</h3> golden grass, which boost grass value by <h3>x" + format(player.g.goldGrassEffect) + "." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "Golden grass value: " + format(player.g.goldGrassVal) + "." }, { "color": "white", "font-size": "20px", "font-family": "monospace" }],
-                    ["blank", "25px"],
-                    ["raw-html", function () { return "<h3>" + formatWhole(player.g.goldGrassCount) + "/" + formatWhole(player.g.goldGrassCap) + " Golden grass." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "<h3>" + format(player.g.goldGrassTimer) + "/" + format(player.g.goldGrassReq) + " Seconds to spawn golden grass." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "<div id=gold-spawn-area class=spawn-area></div>" }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                ]
+                buttonStyle: {
+                    'color': 'white',
+                },
+                unlocked: () => hasUpgrade('g', 13),
+                content: [
+                    ['blank', '25px'],
+                    ['raw-html', () =>
+                        'You have <h3>' + format(player.g.goldGrass) +
+                            '</h3> golden grass, which boost ' +
+                            'grass value by <h3>x' +
+                            format(player.g.goldGrassEffect) + '.',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['raw-html', () =>
+                        'Golden grass value: ' +
+                            format(player.g.goldGrassVal) + '.',
+                        {
+                            'color': 'white',
+                            'font-size': '20px',
+                            'font-family': 'monospace'
+                        },
+                    ],
+                    ['blank', '25px'],
+                    ['raw-html', () =>
+                        '<h3>' + formatWhole(player.g.goldGrassCount) +
+                            '/' + formatWhole(player.g.goldGrassCap) +
+                            ' Golden grass.',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['raw-html', () =>
+                        '<h3>' + format(player.g.goldGrassTimer) + '/' +
+                            format(player.g.goldGrassReq) +
+                            ' Seconds to spawn golden grass.',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['raw-html', () =>
+                        '<div id=gold-spawn-area class=spawn-area></div>',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                ],
             },
             'Moonstone': {
-                buttonStyle() { return { 'color': '#047ce4', "border-color": "#0490f4"} },
-                unlocked() { return player.ev.evolutionsUnlocked[7] },
-                content:
-                [
-                    ["blank", "25px"],
-                    ["raw-html", function () { return "You have <h3>" + format(player.g.moonstone) + "</h3> moonstone, which boost golden grass value by <h3>x" + format(player.g.moonstoneEffect) + "." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "Moonstone value: " + format(player.g.moonstoneVal) + "." }, { "color": "white", "font-size": "20px", "font-family": "monospace" }],
-                    ["blank", "25px"],
-                    ["raw-html", function () { return "<h3>" + formatWhole(player.g.moonstoneCount) + "/" + formatWhole(player.g.moonstoneCap) + " Moonstone. (Click to shoot grass bullets at the moonstone)<h/3><h6>(Max HP: " + format(player.g.moonstoneMaxHealth) + ", Damage: " + format(player.g.moonstoneDamage) + ", Reload Time: " + format(player.g.reloadTime) + " ms, Level: " + formatWhole(player.g.moonstoneLevel) + "/" + formatWhole(player.g.moonstoneLevelMax) + ")" }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "<h3>" + format(player.g.moonstoneTimer) + "/" + format(player.g.moonstoneReq) + " Seconds to spawn moonstone." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "<div id=mainCircle></div>" }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "<div id=moonstone-spawn-area class=spawn-area></div>" }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                ]
+                buttonStyle: {
+                    'color': '#047ce4',
+                    'border-color': '#0490f4'
+                },
+                unlocked: () => player.ev.evolutionsUnlocked[7],
+                content: [
+                    ['blank', '25px'],
+                    ['raw-html', () =>
+                        'You have <h3>' + format(player.g.moonstone) +
+                            '</h3> moonstone, which boost golden grass ' +
+                            'value by <h3>x' +
+                            format(player.g.moonstoneEffect) + '.',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['raw-html', () =>
+                        'Moonstone value: ' +
+                            format(player.g.moonstoneVal) + '.',
+                        {
+                            'color': 'white',
+                            'font-size': '20px',
+                            'font-family': 'monospace'
+                        },
+                    ],
+                    ['blank', '25px'],
+                    ['raw-html', () =>
+                        '<h3>' + formatWhole(player.g.moonstoneCount) +
+                            '/' + formatWhole(player.g.moonstoneCap) +
+                            ' Moonstone. (Click to shoot grass bullets ' +
+                            'at the moonstone)</h3><h6>(Max HP: ' +
+                            format(player.g.moonstoneMaxHealth) +
+                            ', Damage: ' + format(player.g.moonstoneDamage) +
+                            ', Reload Time: ' + format(player.g.reloadTime) +
+                            ' ms, Level: ' +
+                            formatWhole(player.g.moonstoneLevel) +
+                            '/' + formatWhole(player.g.moonstoneLevelMax) +
+                            ')',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['raw-html', () =>
+                        '<h3>' + format(player.g.moonstoneTimer) + '/' +
+                            format(player.g.moonstoneReq) +
+                            ' Seconds to spawn moonstone.',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['raw-html', () =>
+                        '<div id=mainCircle></div>',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['raw-html', () =>
+                        '<div id=moonstone-spawn-area class=spawn-area></div>',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                ],
             },
             'Moonstone Buyables': {
-                buttonStyle() { return { 'color': '#047ce4', "border-color": "#0490f4"} },
-                unlocked() { return player.ev.evolutionsUnlocked[7] },
-                content:
-                [
-                    ["blank", "25px"],
-                    ["raw-html", function () { return "You have <h3>" + format(player.g.moonstone) + "</h3> moonstone." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["blank", "25px"],
-                    ["row", [["clickable", 2], ["clickable", 3]]],
-                    ["blank", "25px"],
-                    ["row", [["buyable", 21], ["buyable", 22], ["buyable", 23], ["buyable", 24]]],
-                    ["row", [["buyable", 25], ["buyable", 26], ["buyable", 27], ["buyable", 28]]],
-
-                ]
+                buttonStyle: {
+                    'color': '#047ce4',
+                    'border-color': '#0490f4'
+                },
+                unlocked: () => player.ev.evolutionsUnlocked[7],
+                content: [
+                    ['blank', '25px'],
+                    ['raw-html', () =>
+                        'You have <h3>' + format(player.g.moonstone) +
+                            '</h3> moonstone.',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['blank', '25px'],
+                    ['row', [
+                        ['clickable', 2],
+                        ['clickable', 3]
+                    ]],
+                    ['blank', '25px'],
+                    ['row', [
+                        ['buyable', 21],
+                        ['buyable', 22],
+                        ['buyable', 23],
+                        ['buyable', 24]
+                    ]],
+                    ['row', [
+                        ['buyable', 25],
+                        ['buyable', 26],
+                        ['buyable', 27],
+                        ['buyable', 28]
+                    ]],
+                ],
             },
             'Moonstone Levels': {
-                buttonStyle() { return { 'color': '#047ce4', "border-color": "#0490f4"} },
-                unlocked() { return player.ev.evolutionsUnlocked[7] },
-                content:
-                [
-                    ["blank", "25px"],
-                    ["raw-html", function () { return "You have <h3>" + format(player.g.moonstone) + "</h3> moonstone." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "<h3>Level: " + formatWhole(player.g.moonstoneLevel) + "/" + formatWhole(player.g.moonstoneLevelMax) + "" }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["blank", "25px"],
-                    ["row", [["buyable", 29]]],
-                    ["blank", "25px"],
-                    ["row", [["clickable", 4], ["clickable", 5]]],
-                    ["blank", "25px"],
-                    ["raw-html", function () { return "<h3>Effects:" }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "<h4>x" + format(player.g.moonstoneLevelEffects[0]) + " to moonstone health." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "<h4>x" + format(player.g.moonstoneLevelEffects[1]) + " to moonstone spawn time." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "<h4>x" + format(player.g.moonstoneLevelEffects[2]) + " to moonstone value." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-
-
-                ]
+                buttonStyle:  {
+                    'color': '#047ce4',
+                    'border-color': '#0490f4'
+                },
+                unlocked: () => player.ev.evolutionsUnlocked[7],
+                content: [
+                    ['blank', '25px'],
+                    ['raw-html', () =>
+                        'You have <h3>' + format(player.g.moonstone) +
+                            '</h3> moonstone.',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['raw-html', () =>
+                        '<h3>Level: ' + formatWhole(player.g.moonstoneLevel) +
+                            '/' + formatWhole(player.g.moonstoneLevelMax),
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['blank', '25px'],
+                    ['row', [
+                        ['buyable', 29]
+                    ]],
+                    ['blank', '25px'],
+                    ['row', [
+                        ['clickable', 4],
+                        ['clickable', 5]
+                    ]],
+                    ['blank', '25px'],
+                    ['raw-html', () =>
+                        '<h3>Effects:',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['raw-html', () =>
+                        '<h4>x' + format(player.g.moonstoneLevelEffects[0]) +
+                            ' to moonstone health.',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['raw-html', () =>
+                        '<h4>x' + format(player.g.moonstoneLevelEffects[1]) +
+                            ' to moonstone spawn time.',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['raw-html', () =>
+                        '<h4>x' + format(player.g.moonstoneLevelEffects[2]) +
+                            ' to moonstone value.',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                ],
             },
             'Buyables': {
-                buttonStyle() { return { 'color': 'white' } },
-                unlocked() { return true },
-                content:
-                [
-                        ["blank", "25px"],
-                        ["row", [["clickable", 2], ["clickable", 3]]],
-                        ["blank", "25px"],
-                        ["row", [["buyable", 11], ["buyable", 12], ["buyable", 13]]],
-                        ["row", [["buyable", 14], ["buyable", 15], ["buyable", 16]]],
-                        ["blank", "25px"],
-                    ["raw-html", function () { return hasUpgrade("g", 13) ? "You have <h3>" + format(player.g.goldGrass) + "</h3> golden grass." : ""}, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-                    ["row", [["buyable", 17], ["buyable", 18], ["buyable", 19]]],
-                ]
+                buttonStyle: {
+                    'color': 'white'
+                },
+                unlocked: true,
+                content: [
+                    ['blank', '25px'],
+                    ['row', [
+                        ['clickable', 2],
+                        ['clickable', 3]
+                    ]],
+                    ['blank', '25px'],
+                    ['row', [
+                        ['buyable', 11],
+                        ['buyable', 12],
+                        ['buyable', 13]
+                    ]],
+                    ['row', [
+                        ['buyable', 14],
+                        ['buyable', 15],
+                        ['buyable', 16]
+                    ]],
+                    ['blank', '25px'],
+                    ['raw-html', () =>
+                        hasUpgrade('g', 13)
+                            ? 'You have <h3>' + format(player.g.goldGrass) +
+                                '</h3> golden grass.'
+                            : '',
+                        {
+                            'color': 'white',
+                            'font-size': '24px',
+                            'font-family': 'monospace',
+                        },
+                    ],
+                    ['row', [
+                        ['buyable', 17],
+                        ['buyable', 18],
+                        ['buyable', 19]
+                    ]],
+                ],
             },
             'Upgrades': {
-                buttonStyle() { return { 'color': 'white' } },
-                unlocked() { return hasMilestone("r", 11) },
-                content:
-                [
-                    ["blank", "25px"],
-                    ["row", [["upgrade", 11], ["upgrade", 12], ["upgrade", 13], ["upgrade", 14], ["upgrade", 15], ["upgrade", 16]]],
-                    ["row", [["upgrade", 17], ["upgrade", 18], ["upgrade", 19], ["upgrade", 21], ["upgrade", 22]]],
-                ]
+                buttonStyle: {
+                    'color': 'white'
+                },
+                unlocked: () => hasMilestone('r', 11),
+                content: [
+                    ['blank', '25px'],
+                    ['row', [
+                        ['upgrade', 11],
+                        ['upgrade', 12],
+                        ['upgrade', 13],
+                        ['upgrade', 14],
+                        ['upgrade', 15],
+                        ['upgrade', 16]
+                    ]],
+                    ['row', [
+                        ['upgrade', 17],
+                        ['upgrade', 18],
+                        ['upgrade', 19],
+                        ['upgrade', 21],
+                        ['upgrade', 22]
+                    ]],
+                ],
             },
         },
     },

--- a/js/grass.js
+++ b/js/grass.js
@@ -2064,8 +2064,6 @@ function createGoldGrass(quantity) {
     spawnArea.append(...newChildren)
 }
 
-var maxHealth = new Decimal(100)
-var damage = new Decimal(20)
 function createMoonstone(quantity) {
     const spawnArea = document.getElementById('moonstone-spawn-area');
     const spawnAreaRect = spawnArea?.getBoundingClientRect();

--- a/js/grass.js
+++ b/js/grass.js
@@ -1,6 +1,6 @@
-﻿addLayer("g", {
-    name: "Grass", // This is optional, only used in a few places, If absent it just uses the layer id.
-    symbol: "G", // This appears on the layer's node. Default is the id with the first letter capitalized
+﻿addLayer('g', {
+    name: 'Grass', // This is optional, only used in a few places, If absent it just uses the layer id.
+    symbol: 'G', // This appears on the layer's node. Default is the id with the first letter capitalized
     row: 1,
     position: 0, // Horizontal position within a row. By default it uses the layer id and sorts in alphabetical order
     startData() { return {
@@ -58,36 +58,36 @@
     }
     },
     automate() {
-        if (hasMilestone("r", 13))
+        if (hasMilestone('r', 13))
         {
-            buyBuyable("g", 11)
-            buyBuyable("g", 12)
-            buyBuyable("g", 13)
-            buyBuyable("g", 14)
-            buyBuyable("g", 15)
-            buyBuyable("g", 16)
-            buyBuyable("g", 17)
-            buyBuyable("g", 18)
-            buyBuyable("g", 19)
+            buyBuyable('g', 11)
+            buyBuyable('g', 12)
+            buyBuyable('g', 13)
+            buyBuyable('g', 14)
+            buyBuyable('g', 15)
+            buyBuyable('g', 16)
+            buyBuyable('g', 17)
+            buyBuyable('g', 18)
+            buyBuyable('g', 19)
         }
-        if (hasMilestone("r", 15) && player.g.auto == true)
+        if (hasMilestone('r', 15) && player.g.auto == true)
         {
-            buyUpgrade("g", 11)
-            buyUpgrade("g", 12)
-            buyUpgrade("g", 13)
-            buyUpgrade("g", 14)
-            buyUpgrade("g", 15)
-            buyUpgrade("g", 16)
-            buyUpgrade("g", 17)
-            buyUpgrade("g", 18)
-            buyUpgrade("g", 19)
-            buyUpgrade("g", 21)
+            buyUpgrade('g', 11)
+            buyUpgrade('g', 12)
+            buyUpgrade('g', 13)
+            buyUpgrade('g', 14)
+            buyUpgrade('g', 15)
+            buyUpgrade('g', 16)
+            buyUpgrade('g', 17)
+            buyUpgrade('g', 18)
+            buyUpgrade('g', 19)
+            buyUpgrade('g', 21)
         }
     },
     nodeStyle() {
     },
-    tooltip: "Grass",
-    color: "#119B35",
+    tooltip: 'Grass',
+    color: '#119B35',
     update(delta) {
         // Grass/gold grass-specific logic relies on knowing whether or
         // not we're actively on their specific microtab, so we handle the
@@ -219,52 +219,52 @@
         removeAllMoonstone()
         createMoonstone(player.g.moonstoneCount)
     },
-    branches: ["t"],
+    branches: ['t'],
     clickables: {
         1: {
-            title() { return "<h2>Return" },
+            title() { return '<h2>Return' },
             canClick() { return true },
             unlocked() { return true },
             onClick() {
-                player.tab = "i"
+                player.tab = 'i'
             },
-            style: { width: '100px', "min-height": '50px' },
+            style: { width: '100px', 'min-height': '50px' },
         },
         2: {
-            title() { return "Buy Max On" },
+            title() { return 'Buy Max On' },
             canClick() { return player.buyMax == false },
             unlocked() { return true },
             onClick() {
                 player.buyMax = true
             },
-            style: { width: '75px', "min-height": '50px', }
+            style: { width: '75px', 'min-height': '50px', }
         },
         3: {
-            title() { return "Buy Max Off" },
+            title() { return 'Buy Max Off' },
             canClick() { return player.buyMax == true  },
             unlocked() { return true },
             onClick() {
                 player.buyMax = false
             },
-            style: { width: '75px', "min-height": '50px', }
+            style: { width: '75px', 'min-height': '50px', }
         },
         4: {
-            title() { return "<h3>Lower Level" },
+            title() { return '<h3>Lower Level' },
             canClick() { return player.g.moonstoneLevel.gt(1) },
             unlocked() { return true },
             onClick() {
                 player.g.moonstoneLevel = player.g.moonstoneLevel.sub(1)
             },
-            style: { width: '100px', "min-height": '100px' },
+            style: { width: '100px', 'min-height': '100px' },
         },
         5: {
-            title() { return "<h3>Increase Level" },
+            title() { return '<h3>Increase Level' },
             canClick() { return player.g.moonstoneLevel.lt(player.g.moonstoneLevelMax) },
             unlocked() { return true },
             onClick() {
                 player.g.moonstoneLevel = player.g.moonstoneLevel.add(1)
             },
-            style: { width: '100px', "min-height": '100px' },
+            style: { width: '100px', 'min-height': '100px' },
         },
     },
     bars: {
@@ -272,129 +272,129 @@
     upgrades: {
         11:
         {
-            title: "Grass Upgrade I",
+            title: 'Grass Upgrade I',
             unlocked() { return true },
-            description() { return "Boosts grass value based on prestige points." },
+            description() { return 'Boosts grass value based on prestige points.' },
             cost: new Decimal(250),
             currencyLocation() { return player.g },
-            currencyDisplayName: "Grass",
-            currencyInternalName: "grass",
+            currencyDisplayName: 'Grass',
+            currencyInternalName: 'grass',
             effect() {
                 return player.p.prestigePoints.pow(0.05).div(9).add(1)
             },
-            effectDisplay() { return format(upgradeEffect(this.layer, this.id))+"x" }, // Add formatting to the effect
+            effectDisplay() { return format(upgradeEffect(this.layer, this.id))+'x' }, // Add formatting to the effect
         },
         12:
         {
-            title: "Grass Upgrade II",
+            title: 'Grass Upgrade II',
             unlocked() { return true },
-            description() { return "Boost tree gain based on grass." },
+            description() { return 'Boost tree gain based on grass.' },
             cost: new Decimal(400),
             currencyLocation() { return player.g },
-            currencyDisplayName: "Grass",
-            currencyInternalName: "grass",
+            currencyDisplayName: 'Grass',
+            currencyInternalName: 'grass',
             effect() {
                 return player.g.grass.pow(0.3).div(7).add(1)
             },
-            effectDisplay() { return format(upgradeEffect(this.layer, this.id))+"x" }, // Add formatting to the effect
+            effectDisplay() { return format(upgradeEffect(this.layer, this.id))+'x' }, // Add formatting to the effect
         },
         13:
         {
-            title: "Grass Upgrade III",
+            title: 'Grass Upgrade III',
             unlocked() { return true },
-            description() { return "Unlocks Golden Grass." },
+            description() { return 'Unlocks Golden Grass.' },
             cost: new Decimal(800),
             currencyLocation() { return player.g },
-            currencyDisplayName: "Grass",
-            currencyInternalName: "grass",
+            currencyDisplayName: 'Grass',
+            currencyInternalName: 'grass',
         },
         14:
         {
-            title: "Grass Upgrade IV",
-            unlocked() { return hasUpgrade("g", 13) },
-            description() { return "Unlocks golden grass buyables." },
+            title: 'Grass Upgrade IV',
+            unlocked() { return hasUpgrade('g', 13) },
+            description() { return 'Unlocks golden grass buyables.' },
             cost: new Decimal(1500),
             currencyLocation() { return player.g },
-            currencyDisplayName: "Grass",
-            currencyInternalName: "grass",
+            currencyDisplayName: 'Grass',
+            currencyInternalName: 'grass',
         },
         15:
         {
-            title: "Grass Upgrade V",
-            unlocked() { return hasUpgrade("g", 13) },
-            description() { return "Unlocks more tree buyables." },
+            title: 'Grass Upgrade V',
+            unlocked() { return hasUpgrade('g', 13) },
+            description() { return 'Unlocks more tree buyables.' },
             cost: new Decimal(3000),
             currencyLocation() { return player.g },
-            currencyDisplayName: "Grass",
-            currencyInternalName: "grass",
+            currencyDisplayName: 'Grass',
+            currencyInternalName: 'grass',
         },
         16:
         {
-            title: "Grass Upgrade VI",
-            unlocked() { return hasUpgrade("g", 13) },
-            description() { return "Divides golden grass spawn time by /1.3." },
+            title: 'Grass Upgrade VI',
+            unlocked() { return hasUpgrade('g', 13) },
+            description() { return 'Divides golden grass spawn time by /1.3.' },
             cost: new Decimal(4500),
             currencyLocation() { return player.g },
-            currencyDisplayName: "Grass",
-            currencyInternalName: "grass",
+            currencyDisplayName: 'Grass',
+            currencyInternalName: 'grass',
         },
         17:
         {
-            title: "Grass Upgrade VII",
-            unlocked() { return hasMilestone("r", 12) },
-            description() { return "Unlocks tree factor V." },
+            title: 'Grass Upgrade VII',
+            unlocked() { return hasMilestone('r', 12) },
+            description() { return 'Unlocks tree factor V.' },
             cost: new Decimal(7777),
             currencyLocation() { return player.g },
-            currencyDisplayName: "Grass",
-            currencyInternalName: "grass",
+            currencyDisplayName: 'Grass',
+            currencyInternalName: 'grass',
         },
         18:
         {
-            title: "Grass Upgrade VIII",
-            unlocked() { return hasMilestone("r", 14) },
-            description() { return "Increases grass capacity by +150 and golden grass by +6." },
+            title: 'Grass Upgrade VIII',
+            unlocked() { return hasMilestone('r', 14) },
+            description() { return 'Increases grass capacity by +150 and golden grass by +6.' },
             cost: new Decimal(1e7),
             currencyLocation() { return player.g },
-            currencyDisplayName: "Grass",
-            currencyInternalName: "grass",
+            currencyDisplayName: 'Grass',
+            currencyInternalName: 'grass',
         },
         19:
         {
-            title: "Grass Upgrade IX",
-            unlocked() { return hasMilestone("r", 14) },
-            description() { return "Increases grass capacity based on pent. (Max: 1000)" },
+            title: 'Grass Upgrade IX',
+            unlocked() { return hasMilestone('r', 14) },
+            description() { return 'Increases grass capacity based on pent. (Max: 1000)' },
             cost: new Decimal(1e9),
             currencyLocation() { return player.g },
-            currencyDisplayName: "Grass",
-            currencyInternalName: "grass",
+            currencyDisplayName: 'Grass',
+            currencyInternalName: 'grass',
             effect() {
                 return player.r.pent.lte(100) ? player.r.pent.mul(10) : new Decimal(1000)
             },
-            effectDisplay() { return "+"+formatWhole(upgradeEffect(this.layer, this.id))}, // Add formatting to the effect
+            effectDisplay() { return '+'+formatWhole(upgradeEffect(this.layer, this.id))}, // Add formatting to the effect
         },
         21:
         {
-            title: "Grass Upgrade X",
-            unlocked() { return hasMilestone("r", 17) },
-            description() { return "Boosts mod gain based on check back level." },
+            title: 'Grass Upgrade X',
+            unlocked() { return hasMilestone('r', 17) },
+            description() { return 'Boosts mod gain based on check back level.' },
             cost: new Decimal(1e25),
             currencyLocation() { return player.g },
-            currencyDisplayName: "Grass",
-            currencyInternalName: "grass",
+            currencyDisplayName: 'Grass',
+            currencyInternalName: 'grass',
             effect() {
                 return player.cb.level.pow(0.8).add(1)
             },
-            effectDisplay() { return "x"+formatWhole(upgradeEffect(this.layer, this.id))}, // Add formatting to the effect
+            effectDisplay() { return 'x'+formatWhole(upgradeEffect(this.layer, this.id))}, // Add formatting to the effect
         },
         22:
         {
-            title: "Grass Upgrade XI",
-            unlocked() { return player.po.realmMods || hasUpgrade("g", 22) },
-            description() { return "Raise golden grass effect by ^6." },
-            cost: new Decimal("1e550"),
+            title: 'Grass Upgrade XI',
+            unlocked() { return player.po.realmMods || hasUpgrade('g', 22) },
+            description() { return 'Raise golden grass effect by ^6.' },
+            cost: new Decimal('1e550'),
             currencyLocation() { return player.g },
-            currencyDisplayName: "Grass",
-            currencyInternalName: "grass",
+            currencyDisplayName: 'Grass',
+            currencyInternalName: 'grass',
         },
     },
     buyables: {
@@ -404,26 +404,26 @@
             unlocked() { return true },
             canAfford() { return player.g.grass.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Grass Value"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Grass Value'
             },
             display() {
-                return "which are boosting grass value by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Grass"
+                return 'which are boosting grass value by x' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Grass'
             },
             buy() {
                 let base = new Decimal(10)
                 let growth = 1.2
-                if (player.buyMax == false && !hasMilestone("r", 13))
+                if (player.buyMax == false && !hasMilestone('r', 13))
                 {
                     let buyonecost = new Decimal(growth).pow(getBuyableAmount(this.layer, this.id)).mul(base)
-                    if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(buyonecost)
+                    if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(buyonecost)
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
 
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
-                if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
+                if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(cost)
 
                 setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
             }
@@ -436,26 +436,26 @@
             unlocked() { return true },
             canAfford() { return player.g.grass.gte(this.cost()) && player.g.buyables[12].lt(200)},
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "/200<br/>Grass Grow Rate"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '/200<br/>Grass Grow Rate'
             },
             display() {
-                return "which are dividing grass time requirement by /" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Grass"
+                return 'which are dividing grass time requirement by /' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Grass'
             },
             buy() {
                 let base = new Decimal(15)
                 let growth = 1.25
-                if (player.buyMax == false && !hasMilestone("r", 13))
+                if (player.buyMax == false && !hasMilestone('r', 13))
                 {
                     let buyonecost = new Decimal(growth).pow(getBuyableAmount(this.layer, this.id)).mul(base)
-                    if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(buyonecost)
+                    if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(buyonecost)
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
 
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
-                if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
+                if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(cost)
 
                 setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
             }
@@ -468,26 +468,26 @@
             unlocked() { return true },
             canAfford() { return player.g.grass.gte(this.cost()) && player.g.buyables[13].lt(500)},
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "/500<br/>Grass Capacity"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '/500<br/>Grass Capacity'
             },
             display() {
-                return "which are increasing grass capacity by +" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Grass"
+                return 'which are increasing grass capacity by +' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Grass'
             },
             buy() {
                 let base = new Decimal(25)
                 let growth = 1.3
-                if (player.buyMax == false && !hasMilestone("r", 13))
+                if (player.buyMax == false && !hasMilestone('r', 13))
                 {
                     let buyonecost = new Decimal(growth).pow(getBuyableAmount(this.layer, this.id)).mul(base)
-                    if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(buyonecost)
+                    if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(buyonecost)
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
 
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
-                if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
+                if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(cost)
 
                 setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
             }
@@ -500,26 +500,26 @@
             unlocked() { return true },
             canAfford() { return player.g.grass.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Grass Celestial Point Boost"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Grass Celestial Point Boost'
             },
             display() {
-                return "which are boosting celestial point gain by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Grass"
+                return 'which are boosting celestial point gain by x' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Grass'
             },
             buy() {
                 let base = new Decimal(20)
                 let growth = 1.22
-                if (player.buyMax == false && !hasMilestone("r", 13))
+                if (player.buyMax == false && !hasMilestone('r', 13))
                 {
                     let buyonecost = new Decimal(growth).pow(getBuyableAmount(this.layer, this.id)).mul(base)
-                    if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(buyonecost)
+                    if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(buyonecost)
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
 
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
-                if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
+                if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(cost)
 
                 setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
             }
@@ -532,26 +532,26 @@
             unlocked() { return true },
             canAfford() { return player.g.grass.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Grass Factor Power Boost"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Grass Factor Power Boost'
             },
             display() {
-                return "which are boosting factor power gain by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Grass"
+                return 'which are boosting factor power gain by x' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Grass'
             },
             buy() {
                 let base = new Decimal(35)
                 let growth = 1.34
-                if (player.buyMax == false && !hasMilestone("r", 13))
+                if (player.buyMax == false && !hasMilestone('r', 13))
                 {
                     let buyonecost = new Decimal(growth).pow(getBuyableAmount(this.layer, this.id)).mul(base)
-                    if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(buyonecost)
+                    if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(buyonecost)
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
 
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
-                if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
+                if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(cost)
 
                 setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
             }
@@ -564,26 +564,26 @@
             unlocked() { return true },
             canAfford() { return player.g.grass.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Grass Prestige Point Boost"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Grass Prestige Point Boost'
             },
             display() {
-                return "which are boosting prestige point gain by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Grass"
+                return 'which are boosting prestige point gain by x' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Grass'
             },
             buy() {
                 let base = new Decimal(60)
                 let growth = 1.4
-                if (player.buyMax == false && !hasMilestone("r", 13))
+                if (player.buyMax == false && !hasMilestone('r', 13))
                 {
                     let buyonecost = new Decimal(growth).pow(getBuyableAmount(this.layer, this.id)).mul(base)
-                    if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(buyonecost)
+                    if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(buyonecost)
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
 
                 let max = Decimal.affordGeometricSeries(player.g.grass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
-                if (!hasMilestone("r", 13)) player.g.grass = player.g.grass.sub(cost)
+                if (!hasMilestone('r', 13)) player.g.grass = player.g.grass.sub(cost)
 
                 setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
             }
@@ -593,29 +593,29 @@
         17: {
             cost(x) { return new Decimal(1.25).pow(x || getBuyableAmount(this.layer, this.id)).mul(4) },
             effect(x) { return new getBuyableAmount(this.layer, this.id).mul(0.05).add(1) },
-            unlocked() { return hasUpgrade("g", 14) },
+            unlocked() { return hasUpgrade('g', 14) },
             canAfford() { return player.g.goldGrass.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Golden Grass Value"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Golden Grass Value'
             },
             display() {
-                return "which are boosting golden grass value by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Golden Grass"
+                return 'which are boosting golden grass value by x' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Golden Grass'
             },
             buy() {
                 let base = new Decimal(4)
                 let growth = 1.25
-                if (player.buyMax == false && !hasMilestone("r", 13))
+                if (player.buyMax == false && !hasMilestone('r', 13))
                 {
                     let buyonecost = new Decimal(growth).pow(getBuyableAmount(this.layer, this.id)).mul(base)
-                    if (!hasMilestone("r", 13)) player.g.goldGrass = player.g.goldGrass.sub(buyonecost)
+                    if (!hasMilestone('r', 13)) player.g.goldGrass = player.g.goldGrass.sub(buyonecost)
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
 
                 let max = Decimal.affordGeometricSeries(player.g.goldGrass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
-                if (!hasMilestone("r", 13)) player.g.goldGrass = player.g.goldGrass.sub(cost)
+                if (!hasMilestone('r', 13)) player.g.goldGrass = player.g.goldGrass.sub(cost)
 
                 setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
             }
@@ -625,29 +625,29 @@
         18: {
             cost(x) { return new Decimal(1.45).pow(x || getBuyableAmount(this.layer, this.id)).mul(8) },
             effect(x) { return new getBuyableAmount(this.layer, this.id) },
-            unlocked() { return hasUpgrade("g", 14) },
+            unlocked() { return hasUpgrade('g', 14) },
             canAfford() { return player.g.goldGrass.gte(this.cost()) && player.g.buyables[18].lt(500)},
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "/500<br/>Golden Grass Capacity"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '/500<br/>Golden Grass Capacity'
             },
             display() {
-                return "which are increasing golden grass capacity by +" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Golden Grass"
+                return 'which are increasing golden grass capacity by +' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Golden Grass'
             },
             buy() {
                 let base = new Decimal(8)
                 let growth = 1.45
-                if (player.buyMax == false && !hasMilestone("r", 13))
+                if (player.buyMax == false && !hasMilestone('r', 13))
                 {
                     let buyonecost = new Decimal(growth).pow(getBuyableAmount(this.layer, this.id)).mul(base)
-                    if (!hasMilestone("r", 13)) player.g.goldGrass = player.g.goldGrass.sub(buyonecost)
+                    if (!hasMilestone('r', 13)) player.g.goldGrass = player.g.goldGrass.sub(buyonecost)
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
 
                 let max = Decimal.affordGeometricSeries(player.g.goldGrass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
-                if (!hasMilestone("r", 13)) player.g.goldGrass = player.g.goldGrass.sub(cost)
+                if (!hasMilestone('r', 13)) player.g.goldGrass = player.g.goldGrass.sub(cost)
 
                 setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
             }
@@ -657,29 +657,29 @@
         19: {
             cost(x) { return new Decimal(1.7).pow(x || getBuyableAmount(this.layer, this.id)).mul(15) },
             effect(x) { return new getBuyableAmount(this.layer, this.id).mul(10).pow(3).add(1) },
-            unlocked() { return hasUpgrade("g", 14) },
+            unlocked() { return hasUpgrade('g', 14) },
             canAfford() { return player.g.goldGrass.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Pent Requirement Divider"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Pent Requirement Divider'
             },
             display() {
-                return "which are dividing pent requirement by /" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Golden Grass"
+                return 'which are dividing pent requirement by /' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Golden Grass'
             },
             buy() {
                 let base = new Decimal(15)
                 let growth = 1.7
-                if (player.buyMax == false && !hasMilestone("r", 13))
+                if (player.buyMax == false && !hasMilestone('r', 13))
                 {
                     let buyonecost = new Decimal(growth).pow(getBuyableAmount(this.layer, this.id)).mul(base)
-                    if (!hasMilestone("r", 13)) player.g.goldGrass = player.g.goldGrass.sub(buyonecost)
+                    if (!hasMilestone('r', 13)) player.g.goldGrass = player.g.goldGrass.sub(buyonecost)
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else
                 {
 
                 let max = Decimal.affordGeometricSeries(player.g.goldGrass, base, growth, getBuyableAmount(this.layer, this.id))
                 let cost = Decimal.sumGeometricSeries(max, base, growth, getBuyableAmount(this.layer, this.id))
-                if (!hasMilestone("r", 13)) player.g.goldGrass = player.g.goldGrass.sub(cost)
+                if (!hasMilestone('r', 13)) player.g.goldGrass = player.g.goldGrass.sub(cost)
 
                 setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
             }
@@ -692,11 +692,11 @@
             unlocked() { return true },
             canAfford() { return player.g.moonstone.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Moonstone Value"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Moonstone Value'
             },
             display() {
-                return "which are boosting moonstone value by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Moonstone"
+                return 'which are boosting moonstone value by x' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Moonstone'
             },
             buy() {
                 let base = new Decimal(2)
@@ -724,11 +724,11 @@
             unlocked() { return true },
             canAfford() { return player.g.moonstone.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Moonstone Damage"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Moonstone Damage'
             },
             display() {
-                return "which are boosting damage dealt to moonstone by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Moonstone"
+                return 'which are boosting damage dealt to moonstone by x' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Moonstone'
             },
             buy() {
                 let base = new Decimal(3)
@@ -756,11 +756,11 @@
             unlocked() { return true },
             canAfford() { return player.g.moonstone.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Moonstone Reload Time"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Moonstone Reload Time'
             },
             display() {
-                return "which are dividing moonstone reload time by /" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Moonstone"
+                return 'which are dividing moonstone reload time by /' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Moonstone'
             },
             buy() {
                 let base = new Decimal(4)
@@ -788,11 +788,11 @@
             unlocked() { return true },
             canAfford() { return player.g.moonstone.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Moonstone Spawn Time"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Moonstone Spawn Time'
             },
             display() {
-                return "which are dividing moonstone spawn time by /" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Moonstone"
+                return 'which are dividing moonstone spawn time by /' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Moonstone'
             },
             buy() {
                 let base = new Decimal(5)
@@ -820,11 +820,11 @@
             unlocked() { return true },
             canAfford() { return player.g.moonstone.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Check Back XP Lunar Boost"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Check Back XP Lunar Boost'
             },
             display() {
-                return "which are boosting check back xp gain by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Moonstone"
+                return 'which are boosting check back xp gain by x' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Moonstone'
             },
             buy() {
                 let base = new Decimal(2)
@@ -852,11 +852,11 @@
             unlocked() { return true },
             canAfford() { return player.g.moonstone.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Replicanti Lunar Boost"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Replicanti Lunar Boost'
             },
             display() {
-                return "which are boosting replicanti mult by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Moonstone"
+                return 'which are boosting replicanti mult by x' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Moonstone'
             },
             buy() {
                 let base = new Decimal(3)
@@ -884,11 +884,11 @@
             unlocked() { return true },
             canAfford() { return player.g.moonstone.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Hex Lunar Boost"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Hex Lunar Boost'
             },
             display() {
-                return "which are boosting hex 0 points by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Moonstone"
+                return 'which are boosting hex 0 points by x' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Moonstone'
             },
             buy() {
                 let base = new Decimal(4)
@@ -916,11 +916,11 @@
             unlocked() { return true },
             canAfford() { return player.g.moonstone.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Challenge Dice Lunar Boost"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Challenge Dice Lunar Boost'
             },
             display() {
-                return "which boosting challenge dice points by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Moonstone"
+                return 'which boosting challenge dice points by x' + format(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Moonstone'
             },
             buy() {
                 let base = new Decimal(5)
@@ -948,11 +948,11 @@
             unlocked() { return true },
             canAfford() { return player.g.moonstone.gte(this.cost()) },
             title() {
-                return format(getBuyableAmount(this.layer, this.id), 0) + "<br/>Increase Max Level"
+                return format(getBuyableAmount(this.layer, this.id), 0) + '<br/>Increase Max Level'
             },
             display() {
-                return "Current max level: " + formatWhole(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + format(tmp[this.layer].buyables[this.id].cost) + " Moonstone"
+                return 'Current max level: ' + formatWhole(tmp[this.layer].buyables[this.id].effect) + '.\n\
+                    Cost: ' + format(tmp[this.layer].buyables[this.id].cost) + ' Moonstone'
             },
             buy() {
                 let base = new Decimal(100)
@@ -984,7 +984,7 @@
     },
     microtabs: {
         stuff: {
-            "Grass": {
+            'Grass': {
                 buttonStyle() { return { 'color': 'white' } },
                 unlocked() { return true },
                 content:
@@ -996,7 +996,7 @@
                         ["blank", "600px"],
             ]
             },
-            "Golden Grass": {
+            'Golden Grass': {
                 buttonStyle() { return { 'color': 'white' } },
                 unlocked() { return hasUpgrade("g", 13) },
                 content:
@@ -1010,7 +1010,7 @@
                     ["raw-html", function () { return "<div id=gold-spawn-area class=spawn-area></div>" }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
                 ]
             },
-            "Moonstone": {
+            'Moonstone': {
                 buttonStyle() { return { 'color': '#047ce4', "border-color": "#0490f4"} },
                 unlocked() { return player.ev.evolutionsUnlocked[7] },
                 content:
@@ -1025,7 +1025,7 @@
                     ["raw-html", function () { return "<div id=moonstone-spawn-area class=spawn-area></div>" }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
                 ]
             },
-            "Moonstone Buyables": {
+            'Moonstone Buyables': {
                 buttonStyle() { return { 'color': '#047ce4', "border-color": "#0490f4"} },
                 unlocked() { return player.ev.evolutionsUnlocked[7] },
                 content:
@@ -1040,7 +1040,7 @@
 
                 ]
             },
-            "Moonstone Levels": {
+            'Moonstone Levels': {
                 buttonStyle() { return { 'color': '#047ce4', "border-color": "#0490f4"} },
                 unlocked() { return player.ev.evolutionsUnlocked[7] },
                 content:
@@ -1061,7 +1061,7 @@
 
                 ]
             },
-            "Buyables": {
+            'Buyables': {
                 buttonStyle() { return { 'color': 'white' } },
                 unlocked() { return true },
                 content:
@@ -1076,7 +1076,7 @@
                     ["row", [["buyable", 17], ["buyable", 18], ["buyable", 19]]],
                 ]
             },
-            "Upgrades": {
+            'Upgrades': {
                 buttonStyle() { return { 'color': 'white' } },
                 unlocked() { return hasMilestone("r", 11) },
                 content:
@@ -1095,7 +1095,7 @@
                         ["row", [["clickable", 1]]],
                         ["microtabs", "stuff", { 'border-width': '0px' }],
         ],
-    layerShown() { return player.startedGame == true && hasUpgrade("i", 17) }
+    layerShown() { return player.startedGame == true && hasUpgrade('i', 17) }
 })
 
 const updateGrass = (delta) => {
@@ -1388,7 +1388,7 @@ const updateGoldGrass = (delta) => {
         .mul(0.15)
         .add(1)
 
-    if (hasUpgrade("g", 22)) {
+    if (hasUpgrade('g', 22)) {
         player.g.goldGrassEffect = player.g.goldGrassEffect
             .pow(6)
     }
@@ -1398,7 +1398,7 @@ const updateGoldGrass = (delta) => {
 
     player.g.goldGrass = player.g.goldGrass
         .add(player.g.goldGrassVal
-            .mul(buyableEffect("gh", 18)
+            .mul(buyableEffect('gh', 18)
                 .mul(delta)
             )
         )
@@ -1421,7 +1421,7 @@ const updateGoldGrass = (delta) => {
     // Infinity Points challenge: Challenge 14
     if (hasUpgrade('ip', 24) && !inChallenge('ip', 14)) {
         player.g.goldGrassVal = player.g.goldGrassVal
-            .add(upgradeEffect("ip", 24))
+            .add(upgradeEffect('ip', 24))
     }
 
     // -------------------------
@@ -1437,22 +1437,22 @@ const updateGoldGrass = (delta) => {
     // Spawn-time logic
 
     player.g.goldGrassReq = new Decimal(40)
-    if (hasUpgrade("g", 16)) {
+    if (hasUpgrade('g', 16)) {
         player.g.goldGrassReq = player.g.goldGrassReq
             .div(1.3)
     }
 
     player.g.goldGrassReq = player.g.goldGrassReq
-        .div(buyableEffect("gh", 12))
+        .div(buyableEffect('gh', 12))
         .div(player.cb.rarePetEffects[2][1])
 
     // =================================================================
     // Cap logic
 
     player.g.goldGrassCap = new Decimal(15)
-        .add(buyableEffect("g", 18))
+        .add(buyableEffect('g', 18))
 
-    if (hasUpgrade("g", 18)) {
+    if (hasUpgrade('g', 18)) {
         player.g.goldGrassCap = player.g.goldGrassCap
             .add(6)
     }
@@ -1872,14 +1872,14 @@ function shootSmallCircle(event) {
     }
 
     // Create a new small circle (as previously defined)
-    if (player.tab == "g" && player.subtabs["g"]["stuff"] == "Moonstone") {
+    if (player.tab == 'g' && player.subtabs['g']['stuff'] == 'Moonstone') {
         const smallCircle = document.createElement('div');
         smallCircle.style.width = '20px';
         smallCircle.style.height = '20px';
         smallCircle.style.backgroundColor = 'green';
         smallCircle.style.borderRadius = '50%';
         smallCircle.style.position = 'absolute';
-        smallCircle.style.border = "2px solid black"; // Add a black border
+        smallCircle.style.border = '2px solid black'; // Add a black border
         smallCircle.style.zIndex = '20'; // Ensures small circles are on top
         document.body.appendChild(smallCircle);
 

--- a/js/grass.js
+++ b/js/grass.js
@@ -1993,8 +1993,9 @@ function removeAllMoonstone() {
 window.addEventListener('load', function() {
     // This function will be executed after the page is reloaded
     // You can perform any necessary tasks here
-    layers.g.loadGrass();
-    layers.g.loadGoldGrass();
+    layers.g.loadGrass()
+    layers.g.loadGoldGrass()
+    layers.g.loadMoonstone()
 });
 
 

--- a/js/grass.js
+++ b/js/grass.js
@@ -1841,6 +1841,38 @@ function getDistance(x1, y1, x2, y2) {
     return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
 }
 
+// XXX: testing shows that this function returns true _very_ infrequently, e.g.
+// after reloading the grass microtab ~30 times with 1250 grass, I got only
+// 30 exact occlusions, total; if we had fewer grass squares on the board,
+// we should expect the exact occlusion count to drop precipitously, as well.
+function doesOcclude(selector, x, y) {
+    // Valid selectors (so far):
+    //    .green-square
+    //    .gold-square
+    //    .moonstone
+    const elements = document.querySelectorAll(selector)
+    for (let i = 0; i < elements.length; ++i) {
+        const ele = elements[i]
+
+        // 1) All grass/golden grass/moonstone squares are the exact
+        //    same size as others of their type
+        // 2) We have exact overlap if the left and top are exact matches
+        // 3) We are okay with partial overlap, but NOT with exact overlap
+        //
+        // N.B. getBoundingClientRect() is much more expensive than
+        // accessing offsetLeft and offsetTop directly
+        const isExactOverlap = (x === ele.offsetLeft) && (y === ele.offsetTop)
+        if (isExactOverlap) {
+            // Debugging output!
+            // console.log('occlude!')
+
+            return true
+        }
+    }
+
+    return false
+}
+
 function createGrass(quantity) {
     // This _shouldn't_ happen, but there existed cases where e.g.
     // player.g.savedGrass (when it used to exist) somehow got a
@@ -1865,7 +1897,7 @@ function createGrass(quantity) {
         do {
             randomX = Math.floor(Math.random() * (spawnAreaRect.width - 20)); // Adjust to ensure squares spawn within horizontal range
             randomY = Math.floor(Math.random() * (spawnAreaRect.height - 20)); // Adjust to ensure squares spawn within vertical range
-        } while (isCollision(randomX, randomY));
+        } while (doesOcclude('.green-square', randomX, randomY));
 
         const greenSquare = document.createElement('div');
         greenSquare.style.width = '20px';
@@ -1905,17 +1937,6 @@ function createGrass(quantity) {
         // Add the mousemove event listener to check the distance from the cursor
         document.addEventListener('mousemove', checkCursorDistance);
     }
-}
-
-function isCollision(x, y) {
-    const existingGrassSquares = document.querySelectorAll('.green-square');
-    for (let i = 0; i < existingGrassSquares.length; i++) {
-        const squareRect = existingGrassSquares[i].getBoundingClientRect();
-        if (x >= squareRect.left && x <= squareRect.right && y >= squareRect.top && y <= squareRect.bottom) {
-            return true; // Collision detecteds
-        }
-    }
-    return false; // No collision detected
 }
 
 function removeGrass(square) {
@@ -1961,7 +1982,7 @@ function createGoldGrass(quantity) {
         do {
             randomX = Math.floor(Math.random() * (spawnAreaRect.width - 20)); // Adjust to ensure squares spawn within horizontal range
             randomY = Math.floor(Math.random() * (spawnAreaRect.height - 20)); // Adjust to ensure squares spawn within vertical range
-        } while (isCollision(randomX, randomY));
+        } while (doesOcclude('.gold-square', randomX, randomY));
 
         const goldSquare = document.createElement('div');
         goldSquare.style.width = '20px';
@@ -2029,7 +2050,7 @@ function createMoonstone(quantity) {
         do {
             randomX = Math.floor(Math.random() * (spawnAreaRect.width - 20));
             randomY = Math.floor(Math.random() * (spawnAreaRect.height - 20));
-        } while (isCollision(randomX, randomY));
+        } while (doesOcclude('.moonstone', randomX, randomY));
 
         const moonstone = document.createElement('div');
         moonstone.style.width = '20px';

--- a/js/grass.js
+++ b/js/grass.js
@@ -1742,34 +1742,41 @@ const updateMoonstone = (delta) => {
     // Timer logic
 
     // Timer is always running if we're below grass cap
-    const belowMoonstoneCap = player.g.moonstoneCount.lt(player.g.moonstoneCap);
-    if (belowMoonstoneCap) player.g.moonstoneTimer = player.g.moonstoneTimer.add(seconds);
+    const belowMoonstoneCap = player.g.moonstoneCount.lt(player.g.moonstoneCap)
+    if (belowMoonstoneCap) {
+        player.g.moonstoneTimer = player.g.moonstoneTimer
+            .add(seconds)
+    }
 
-    const passedMoonstoneSpawnTime = player.g.moonstoneTimer.gte(player.g.moonstoneReq);
+    const passedMoonstoneSpawnTime =
+        player.g.moonstoneTimer.gte(player.g.moonstoneReq)
 
     if (passedMoonstoneSpawnTime && belowMoonstoneCap) {
-        const moonstoneToAdd = player.g.moonstoneTimer.div(player.g.moonstoneReq).floor();
+        const moonstoneToAdd = player.g.moonstoneTimer
+            .div(player.g.moonstoneReq)
+            .floor()
 
         // Add moonstone
         if (belowMoonstoneCap) {
-            player.g.moonstoneCount = player.g.moonstoneCount.add(moonstoneToAdd);
+            player.g.moonstoneCount = player.g.moonstoneCount
+                .add(moonstoneToAdd)
         }
 
         // Sanity check: respect the cap
         if (player.g.moonstoneCount.gt(player.g.moonstoneCap)) {
-            player.g.moonstoneCount = player.g.moonstoneCap;
+            player.g.moonstoneCount = player.g.moonstoneCap
         }
 
         // Only create when we're loaded
         if (player.g.isMoonstoneLoaded) {
-            createMoonstone(moonstoneToAdd);
+            createMoonstone(moonstoneToAdd)
         }
 
         // Reset the timer
-        player.g.moonstoneTimer = new Decimal(0);
+        player.g.moonstoneTimer = new Decimal(0)
     } else if (passedMoonstoneSpawnTime && !belowMoonstoneCap) {
         // Reset the timer
-        player.g.moonstoneTimer = new Decimal(0);
+        player.g.moonstoneTimer = new Decimal(0)
     }
 
     player.g.reloadTime = new Decimal(400)
@@ -1813,7 +1820,8 @@ const updateMoonstone = (delta) => {
         .mul(player.g.moonstoneLevelEffects[2])
 
     if (hasUpgrade('ev8', 17)) {
-        player.g.moonstoneVal = player.g.moonstoneVal.mul(2)
+        player.g.moonstoneVal = player.g.moonstoneVal
+            .mul(2)
     }
 
     // =================================================================

--- a/js/grass.js
+++ b/js/grass.js
@@ -141,7 +141,6 @@
                 layers.g.loadMoonstone()
                 player.g.isMoonstoneLoaded = true
             }
-
         }
 
         // Grass isn't loaded if we leave its microtab
@@ -176,7 +175,6 @@
         }
 
         // =================================================================
-
 
         updateGrass(delta)
         updateGoldGrass(delta)

--- a/js/grass.js
+++ b/js/grass.js
@@ -1334,11 +1334,33 @@
     },
 
     tabFormat: [
-                        ["raw-html", function () { return "You have <h3>" + format(player.g.grass) + "</h3> grass, which boost leaf gain by <h3>x" + format(player.g.grassEffect) + "." }, { "color": "white", "font-size": "24px", "font-family": "monospace" }],
-         ["raw-html", function () { return "Grass value: " + format(player.g.grassVal) + "." }, { "color": "white", "font-size": "20px", "font-family": "monospace" }],
-                        ["row", [["clickable", 1]]],
-                        ["microtabs", "stuff", { 'border-width': '0px' }],
+        ['raw-html', () =>
+            'You have <h3>' + format(player.g.grass) +
+                '</h3> grass, which boost leaf gain by <h3>x' +
+                format(player.g.grassEffect) + '.',
+            {
+                'color': 'white',
+                'font-size': '24px',
+                'font-family': 'monospace',
+            },
         ],
+        ['raw-html', () =>
+            'Grass value: ' + format(player.g.grassVal) + '.',
+            {
+                'color': 'white',
+                'font-size': '20px',
+                'font-family': 'monospace',
+            },
+        ],
+        ['row', [
+            ['clickable', 1]
+        ]],
+        ['microtabs', 'stuff',
+            {
+                'border-width': '0px'
+            }
+        ],
+    ],
     layerShown() { return player.startedGame == true && hasUpgrade('i', 17) }
 })
 

--- a/js/grass.js
+++ b/js/grass.js
@@ -49,7 +49,11 @@
         moonstoneDamage: new Decimal(20),
         reloadTime: new Decimal(400),
         moonstoneLevel: new Decimal(1),
-        moonstoneLevelEffects: [new Decimal(1),new Decimal(1),new Decimal(1),],
+        moonstoneLevelEffects: [
+            new Decimal(1),
+            new Decimal(1),
+            new Decimal(1),
+        ],
         moonstoneLevelMax: new Decimal(1),
     }
     },
@@ -177,24 +181,6 @@
         updateGrass(delta)
         updateGoldGrass(delta)
         updateMoonstone(delta)
-
-        player.g.moonstoneLevelEffects = [
-        player.g.moonstoneLevel.pow(1.5),
-        player.g.moonstoneLevel.pow(0.2),
-        player.g.moonstoneLevel.pow(1.2)
-        ]
-
-        player.g.moonstoneMaxHealth = new Decimal(100)
-        player.g.moonstoneMaxHealth = player.g.moonstoneMaxHealth.mul(player.g.moonstoneLevelEffects[0])
-
-        player.g.moonstoneDamage = new Decimal(20)
-        player.g.moonstoneDamage = player.g.moonstoneDamage.mul(buyableEffect("g", 22))
-        if (hasUpgrade("ev8", 18)) player.g.moonstoneDamage = player.g.moonstoneDamage.mul(2)
-
-        player.g.reloadTime = new Decimal(400)
-        player.g.reloadTime = player.g.reloadTime.div(buyableEffect("g", 23))
-
-        player.g.moonstoneLevelMax = buyableEffect("g", 29)
     },
     unloadGrass() {
         // N.B. this space intentionally left blank
@@ -1521,6 +1507,10 @@ const updateMoonstone = (delta) => {
         // Reset the timer
         player.g.moonstoneTimer = new Decimal(0);
     }
+
+    player.g.reloadTime = new Decimal(400)
+        .div(buyableEffect('g', 23))
+
     // =================================================================
     // Effect logic
 
@@ -1528,29 +1518,46 @@ const updateMoonstone = (delta) => {
         .mul(4)
         .pow(1.5)
         .add(1)
+
+    player.g.moonstoneLevelEffects = [
+        player.g.moonstoneLevel.pow(1.5),
+        player.g.moonstoneLevel.pow(0.2),
+        player.g.moonstoneLevel.pow(1.2)
+    ]
+
+    player.g.moonstoneMaxHealth = new Decimal(100)
+        .mul(player.g.moonstoneLevelEffects[0])
+
+    player.g.moonstoneDamage = new Decimal(20)
+        .mul(buyableEffect('g', 22))
+    if (hasUpgrade('ev8', 18)) {
+        player.g.moonstoneDamage = player.g.moonstoneDamage.mul(2)
+    }
+
+    player.g.moonstoneLevelMax = buyableEffect('g', 29)
+
     // =================================================================
     // Currency logic
 
-    /*player.g.goldGrass = player.g.goldGrass
-        .add(player.g.goldGrassVal
-            .mul(buyableEffect("gh", 18)
-                .mul(delta)
-            )
-        ) */
+    // ...
 
     // =================================================================
     // Value logic
 
     player.g.moonstoneVal = new Decimal(1)
-    player.g.moonstoneVal = player.g.moonstoneVal.mul(buyableEffect("g", 21))
-    player.g.moonstoneVal = player.g.moonstoneVal.mul(player.g.moonstoneLevelEffects[2])
-    if (hasUpgrade("ev8", 17)) player.g.moonstoneVal = player.g.moonstoneVal.mul(2)
+        .mul(buyableEffect('g', 21))
+        .mul(player.g.moonstoneLevelEffects[2])
+
+    if (hasUpgrade('ev8', 17)) {
+        player.g.moonstoneVal = player.g.moonstoneVal.mul(2)
+    }
+
     // =================================================================
     // Spawn-time logic
 
     player.g.moonstoneReq = new Decimal(15)
-    player.g.moonstoneReq = player.g.moonstoneReq.div(buyableEffect("g", 24))
-    player.g.moonstoneReq = player.g.moonstoneReq.mul(player.g.moonstoneLevelEffects[1])
+        .div(buyableEffect('g', 24))
+        .mul(player.g.moonstoneLevelEffects[1])
 
     // =================================================================
     // Cap logic

--- a/js/grass.js
+++ b/js/grass.js
@@ -1866,8 +1866,10 @@ function createMoonstone(quantity) {
 // Ensure this function is called correctly to spawn moonstones
 
 function shootSmallCircle(event) {
-    // Check if the player can shoot
-    if (!canShoot) return; // Exit if cooldown is active
+    // Sanity check: is cooldown active?
+    if (!canShoot) {
+        return
+    }
 
     // Create a new small circle (as previously defined)
     if (player.tab == "g" && player.subtabs["g"]["stuff"] == "Moonstone") {

--- a/js/grass.js
+++ b/js/grass.js
@@ -1950,16 +1950,19 @@ function removeGrass(square) {
 
 function removeAllGrass() {
     const squares = document.querySelectorAll('.green-square');
-    squares.forEach(square => square.parentNode.removeChild(square));
+    squares.forEach(square => removeGrass(square));
 }
+
 function removeAllGoldGrass() {
     const squares = document.querySelectorAll('.gold-square');
-    squares.forEach(square => square.parentNode.removeChild(square));
+    squares.forEach(square => removeGrass(square));
 }
+
 function removeAllMoonstone() {
     const squares = document.querySelectorAll('moonstone');
-    squares.forEach(square => square.parentNode.removeChild(square));
+    squares.forEach(square => removeGrass(square));
 }
+
 window.addEventListener('load', function() {
     // This function will be executed after the page is reloaded
     // You can perform any necessary tasks here

--- a/js/grass.js
+++ b/js/grass.js
@@ -89,11 +89,6 @@
         // not we're actively on their specific microtab, so we handle the
         // loading/unloading logic here, before splitting off into specific
         // sub-handlers.
-        if (player.g.buyables[13].gte(13))
-        {
-            player.g.buyables[13] = new Decimal(500)
-        }
-
         const state = {
             // I.e. we currently have the Grass layer loaded
             inGrassLayer: player.tab === 'g',
@@ -1132,6 +1127,12 @@ const updateGrass = (delta) => {
     // XXX: in what cases does this get pushed over 200, and why?
     if (player.g.buyables[12].gt(200)) {
         player.g.buyables[12] = new Decimal(200)
+    }
+
+    // Cap grass capacity at 500
+    // XXX: why are we jumping from 13 to 500?
+    if (player.g.buyables[13].gte(13)) {
+        player.g.buyables[13] = new Decimal(500)
     }
 
     // =================================================================

--- a/js/grass.js
+++ b/js/grass.js
@@ -1644,6 +1644,11 @@ function isCollision(x, y) {
 }
 
 function removeGrass(square) {
+    // Sanity check: only remove squares with parents
+    if (!square.parentNode) {
+        return
+    }
+
     square.parentNode.removeChild(square);
 }
 
@@ -1857,19 +1862,6 @@ function createMoonstone(quantity) {
         });
     }
 }
-
-function removeGrass(moonstone) {
-    if (moonstone.parentNode) {
-        moonstone.parentNode.removeChild(moonstone); // Remove the moonstone from DOM
-    }
-}
-
-function isCollision(x, y) {
-    // This function should check if there is a collision
-    // Implement collision logic according to your game requirements
-    return false; // Modify this logic based on your collision detection requirements
-}
-
 
 // Ensure this function is called correctly to spawn moonstones
 

--- a/js/grass.js
+++ b/js/grass.js
@@ -1361,7 +1361,7 @@
             }
         ],
     ],
-    layerShown() { return player.startedGame == true && hasUpgrade('i', 17) }
+    layerShown: () => player.startedGame && hasUpgrade('i', 17),
 })
 
 const updateGrass = (delta) => {

--- a/js/grass.js
+++ b/js/grass.js
@@ -1837,6 +1837,10 @@ const updateMoonstone = (delta) => {
     player.g.moonstoneCap = player.cb.evolvedEffects[7][0]
 }
 
+function getDistance(x1, y1, x2, y2) {
+    return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
+}
+
 function createGrass(quantity) {
     // This _shouldn't_ happen, but there existed cases where e.g.
     // player.g.savedGrass (when it used to exist) somehow got a
@@ -1851,11 +1855,8 @@ function createGrass(quantity) {
     const spawnArea = document.getElementById('spawn-area');
     const spawnAreaRect = spawnArea?.getBoundingClientRect();
 
-    if (!spawnAreaRect) return; // Exit if spawnAreaRect is null or undefined
-
-    // Function to calculate the distance between two points
-    function getDistance(x1, y1, x2, y2) {
-        return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
+    if (!spawnAreaRect) {
+        return
     }
 
     // Create grass squares based on quantity
@@ -1950,11 +1951,8 @@ function createGoldGrass(quantity) {
     const spawnArea = document.getElementById('gold-spawn-area');
     const spawnAreaRect = spawnArea?.getBoundingClientRect();
 
-    if (!spawnAreaRect) return; // Exit if spawnAreaRect is null or undefined
-
-    // Function to calculate the distance between two points
-    function getDistance(x1, y1, x2, y2) {
-        return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
+    if (!spawnAreaRect) {
+        return
     }
 
     // Create golden grass squares based on quantity


### PR DESCRIPTION
This PR reformats and refactors the Grass tab.

The most notable noticeable changes include:

- Grass loading should be faster than mainline
- Grass/golden grass should no longer render right at the border of the spawn area

Less-obvious changes include:

- Moonstone code has been streamlined and modified for clarity
- Microtab code has been reformatted for clarity

Unchanged, but in the queue for future refactor/reformat efforts:

- Clickables
- Upgrades
- Buyables

Being that this is mainly a refactoring PR, major functionality should not be changed (confirmed so far by Peterpicher, who did a testing run). As always, testing locally is recommended prior to merging; if anything needs fixing prior to merge or if any changes are unclear, _please_ let me know.