### PR TITLE
Hopefully squashing the challenge bug once and for all

### DIFF
--- a/js/infinity.js
+++ b/js/infinity.js
@@ -47,6 +47,34 @@ addLayer("in", {
 
         if (player.in.reachedInfinity) {
             if (!player.in.breakInfinity) {
+                if (inChallenge("ip", 11) && !hasChallenge("ip", 11)) {
+                    player.ip.challenges[11] = 1
+                    completeChallenge("ip", 11)
+                }
+                if (inChallenge("ip", 12) && !hasChallenge("ip", 12)) {
+                    player.ip.challenges[12] = 1
+                    completeChallenge("ip", 12)
+                }
+                if (inChallenge("ip", 13) && !hasChallenge("ip", 13)) {
+                    player.ip.challenges[13] = 1
+                    completeChallenge("ip", 13)
+                }
+                if (inChallenge("ip", 14) && !hasChallenge("ip", 14)) {
+                    player.ip.challenges[14] = 1
+                    completeChallenge("ip", 14)
+                }
+                if (inChallenge("ip", 15) && !hasChallenge("ip", 15)) {
+                    player.ip.challenges[15] = 1
+                    completeChallenge("ip", 15)
+                }
+                if (inChallenge("ip", 16) && !hasChallenge("ip", 16)) {
+                    player.ip.challenges[16] = 1
+                    completeChallenge("ip", 16)
+                }
+                if (inChallenge("ip", 18) && !hasChallenge("ip", 18)) {
+                    player.ip.challenges[18] = 1
+                    completeChallenge("ip", 18)
+                }
                 if (inChallenge("tad", 11)) {
                     if (player.bi.brokenInfinities.gt(player.tad.shatteredInfinitiesToGet) && player.po.hex && !player.po.dice && !player.po.rocketFuel && inChallenge("tad", 11) && player.tad.currentConversion.eq(0)) {
                         player.tad.shatteredInfinities = player.tad.shatteredInfinities.add(player.tad.shatteredInfinitiesToGet)
@@ -61,7 +89,7 @@ addLayer("in", {
                         player.bi.brokenInfinities = player.bi.brokenInfinities.sub(player.tad.corruptedInfinitiesToGet)
                     }
                 }
-                if ((!hasMilestone("ip", 21) && ((!player.s.highestSingularityPoints.gt(0)) || player.points.gte(1e308))) || inChallenge("ip", 11) || inChallenge("ip", 12) || inChallenge("ip", 13) || inChallenge("ip", 14) || inChallenge("ip", 15) || inChallenge("ip", 16) || inChallenge("ip", 18)) {
+                if (!hasMilestone("ip", 21) && ((!player.s.highestSingularityPoints.gt(0)) || player.points.gte(1e308))) {
                     player.tab = "bigc"
                 } else if (hasMilestone("ip", 21)) {
                     layers.bigc.crunch()
@@ -489,27 +517,6 @@ addLayer("bigc", {
             canClick() { return true },
             unlocked() { return true },
             onClick() {
-                if (inChallenge("ip", 11) && !hasChallenge("ip", 11)) {
-                    completeChallenge("ip", 11)
-                }
-                if (inChallenge("ip", 12) && !hasChallenge("ip", 12)) {
-                    completeChallenge("ip", 12)
-                }
-                if (inChallenge("ip", 13) && !hasChallenge("ip", 13)) {
-                    completeChallenge("ip", 13)
-                }
-                if (inChallenge("ip", 14) && !hasChallenge("ip", 14)) {
-                    completeChallenge("ip", 14)
-                }
-                if (inChallenge("ip", 15) && !hasChallenge("ip", 15)) {
-                    completeChallenge("ip", 15)
-                }
-                if (inChallenge("ip", 16) && !hasChallenge("ip", 16)) {
-                    completeChallenge("ip", 16)
-                }
-                if (inChallenge("ip", 18) && !hasChallenge("ip", 18)) {
-                    completeChallenge("ip", 18)
-                }
                 if (options.newMenu) {
                     player.tab = "ip"
                 } else {

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -61,8 +61,7 @@ addLayer("in", {
                         player.bi.brokenInfinities = player.bi.brokenInfinities.sub(player.tad.corruptedInfinitiesToGet)
                     }
                 }
-                if (!hasMilestone("ip", 21) && ((!player.s.highestSingularityPoints.gt(0)) || player.points.gte(1e308)))
-                {
+                if ((!hasMilestone("ip", 21) && ((!player.s.highestSingularityPoints.gt(0)) || player.points.gte(1e308))) || inChallenge("ip", 11) || inChallenge("ip", 12) || inChallenge("ip", 13) || inChallenge("ip", 14) || inChallenge("ip", 15) || inChallenge("ip", 16) || inChallenge("ip", 18)) {
                     player.tab = "bigc"
                 } else if (hasMilestone("ip", 21)) {
                     layers.bigc.crunch()
@@ -129,27 +128,6 @@ addLayer("in", {
                     if (player.po.hex) player.ta.highestHex1Points = player.h.hexPoints[0]
                 }
             }
-        if (inChallenge("ip", 11) && !hasChallenge("ip", 11) && player.points.gt(1e300)) {
-            completeChallenge("ip", 11)
-        }
-        if (inChallenge("ip", 12) && !hasChallenge("ip", 12) && player.points.gt(1e300)) {
-            completeChallenge("ip", 12)
-        }
-        if (inChallenge("ip", 13) && !hasChallenge("ip", 13) && player.points.gt(1e300)) {
-            completeChallenge("ip", 13)
-        }
-        if (inChallenge("ip", 14) && !hasChallenge("ip", 14) && player.points.gt(1e300)) {
-            completeChallenge("ip", 14)
-        }
-        if (inChallenge("ip", 15) && !hasChallenge("ip", 15) && player.points.gt(1e300)) {
-            completeChallenge("ip", 15)
-        }
-        if (inChallenge("ip", 16) && !hasChallenge("ip", 16) && player.points.gt(1e300)) {
-            completeChallenge("ip", 16)
-        }
-        if (inChallenge("ip", 18) && !hasChallenge("ip", 18) && player.points.gt(1e300)) {
-            completeChallenge("ip", 18)
-        }
         player.points = new Decimal(10)
         player.r.rank = new Decimal(0)
         player.r.tier = new Decimal(0)
@@ -537,6 +515,38 @@ addLayer("bigc", {
         if (player.po.hex)
         {
             player.ip.hexRuns = player.ip.hexRuns.add(1)
+        }
+        if (inChallenge("ip", 11) && !hasChallenge("ip", 11)) {
+            completeChallenge("ip", 11)
+        }
+        if (inChallenge("ip", 12) && !hasChallenge("ip", 12)) {
+            completeChallenge("ip", 12)
+        }
+        if (inChallenge("ip", 13) && !hasChallenge("ip", 13)) {
+            completeChallenge("ip", 13)
+        }
+        if (inChallenge("ip", 14) && !hasChallenge("ip", 14)) {
+            completeChallenge("ip", 14)
+        }
+        if (inChallenge("ip", 15) && !hasChallenge("ip", 15)) {
+            completeChallenge("ip", 15)
+        }
+        if (inChallenge("ip", 16) && !hasChallenge("ip", 16)) {
+            completeChallenge("ip", 16)
+        }
+        if (inChallenge("ip", 18) && !hasChallenge("ip", 18)) {
+            completeChallenge("ip", 18)
+        }
+        if (hasUpgrade("ta", 17)) {
+            if (player.d.dicePoints.gt(player.ta.highestDicePoints)) {
+                player.ta.highestDicePoints = player.d.dicePoints
+            }
+            if (player.rf.rocketFuel.gt(player.ta.highestRocketFuel)) {
+                player.ta.highestRocketFuel = player.rf.rocketFuel
+            }
+            if (player.h.hexPoints[0].gt(player.ta.highestHex1Points)) {
+                if (player.po.hex) player.ta.highestHex1Points = player.h.hexPoints[0]
+            }
         }
         layers.in.bigCrunch()
         player.in.reachedInfinity = false

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -45,7 +45,7 @@ addLayer("in", {
             player.in.unlockedInfinity = true
         }
 
-        if (player.in.reachedInfinity && !inChallenge("ip", 18)) {
+        if (player.in.reachedInfinity) {
             if (!player.in.breakInfinity) {
                 if (inChallenge("tad", 11)) {
                     if (player.bi.brokenInfinities.gt(player.tad.shatteredInfinitiesToGet) && player.po.hex && !player.po.dice && !player.po.rocketFuel && inChallenge("tad", 11) && player.tad.currentConversion.eq(0)) {
@@ -489,6 +489,27 @@ addLayer("bigc", {
             canClick() { return true },
             unlocked() { return true },
             onClick() {
+                if (inChallenge("ip", 11) && !hasChallenge("ip", 11)) {
+                    completeChallenge("ip", 11)
+                }
+                if (inChallenge("ip", 12) && !hasChallenge("ip", 12)) {
+                    completeChallenge("ip", 12)
+                }
+                if (inChallenge("ip", 13) && !hasChallenge("ip", 13)) {
+                    completeChallenge("ip", 13)
+                }
+                if (inChallenge("ip", 14) && !hasChallenge("ip", 14)) {
+                    completeChallenge("ip", 14)
+                }
+                if (inChallenge("ip", 15) && !hasChallenge("ip", 15)) {
+                    completeChallenge("ip", 15)
+                }
+                if (inChallenge("ip", 16) && !hasChallenge("ip", 16)) {
+                    completeChallenge("ip", 16)
+                }
+                if (inChallenge("ip", 18) && !hasChallenge("ip", 18)) {
+                    completeChallenge("ip", 18)
+                }
                 if (options.newMenu) {
                     player.tab = "ip"
                 } else {
@@ -515,27 +536,6 @@ addLayer("bigc", {
         if (player.po.hex)
         {
             player.ip.hexRuns = player.ip.hexRuns.add(1)
-        }
-        if (inChallenge("ip", 11) && !hasChallenge("ip", 11)) {
-            completeChallenge("ip", 11)
-        }
-        if (inChallenge("ip", 12) && !hasChallenge("ip", 12)) {
-            completeChallenge("ip", 12)
-        }
-        if (inChallenge("ip", 13) && !hasChallenge("ip", 13)) {
-            completeChallenge("ip", 13)
-        }
-        if (inChallenge("ip", 14) && !hasChallenge("ip", 14)) {
-            completeChallenge("ip", 14)
-        }
-        if (inChallenge("ip", 15) && !hasChallenge("ip", 15)) {
-            completeChallenge("ip", 15)
-        }
-        if (inChallenge("ip", 16) && !hasChallenge("ip", 16)) {
-            completeChallenge("ip", 16)
-        }
-        if (inChallenge("ip", 18) && !hasChallenge("ip", 18)) {
-            completeChallenge("ip", 18)
         }
         if (hasUpgrade("ta", 17)) {
             if (player.d.dicePoints.gt(player.ta.highestDicePoints)) {

--- a/js/infinityPoints.js
+++ b/js/infinityPoints.js
@@ -768,7 +768,7 @@
         },
         18: {
             name: "Challenge VIII",
-            challengeDescription() { return "<h4>Debuffs so strong they distort the limits of the universe. You'd hate it, but there will still be worse things to come." },
+            challengeDescription() { return "<h4>Debuffs so strong they distort the universe. You'd hate it, but there will still be worse things to come." },
             goalDescription() { return "1.79e308 celestial points" },
             goal() { return new Decimal("1.79e308") },
             canComplete: function () { return player.points.gte(1.79e308) },


### PR DESCRIPTION
Apparently the `challengeComplete()` function just presses the start/exit/clear challenge button. This is problematic, since that means that it will ONLY give you the clear if your points are above 1e308. I changed it to `player.ip.challenge[1x] = 1`, with x being the challenge number, which properly clears the challenge every time.