### PR TITLE
Fix firefox core processing error

### DIFF
--- a/js/Singularity/coreProcessor.js
+++ b/js/Singularity/coreProcessor.js
@@ -202,6 +202,7 @@
 
                 player.cop.processedCoreStrength = player.coa.coreStrengths[player.coa.coreIndex]
                 player.cop.processedCoreFuel = player.coa.coreFuelSources[player.coa.coreIndex]
+                player.cop.processedCoreInnateEffects = layers.coa.determineEffect(player.cop.processedCoreFuel, player.cop.processedCoreStrength)
                 player.cop.processedCorePrime = player.coa.corePrimes[player.coa.coreIndex]
                 player.cop.processingCore = true
                 


### PR DESCRIPTION
update the processedCoreInnateEffects immediately so the update loop happening with different synchronicity (like on firefox) doesn't cause an error in the update loop requiring a refresh