### PR TITLE
Update rocketFuel.js

### DIFF
--- a/js/rocketFuel.js
+++ b/js/rocketFuel.js
@@ -401,7 +401,7 @@
         player.r.tiersToGet = new Decimal(0)
         player.r.tetrsToGet = new Decimal(0)
         player.r.pentToGet = new Decimal(0)
-        player.r.pent = new Decimal(0)
+        if (!hasUpgrade("rf", 11)) { player.r.pent = new Decimal(0) }
 
         player.f.factorUnlocks = [true, true, true, false, false, false, false, false]
         player.f.factorGain = new Decimal(1)


### PR DESCRIPTION
Makes pent not reset if rocket fuel upgrade one is bought, as it should