### PR TITLE
Hex Hotfix 2

### DIFF
--- a/css/system-style.css
+++ b/css/system-style.css
@@ -72,7 +72,8 @@
 	display: flex;
 	flex-direction: row;
 	flex-wrap: nowrap;
-	overflow-x: scroll;
+	overflow-y: hidden;
+	overflow-x: auto;
 	scroll-behavior: smooth;
   	-webkit-overflow-scrolling: touch;
 	white-space: nowrap;

--- a/css/system-style.css
+++ b/css/system-style.css
@@ -85,6 +85,7 @@
 	display: inline-block;
   	flex: 0 0 auto;
 	margin: 0;
+	min-width: 70px;
 	width: 19%;
 	height: 100%;
 	color: rgba(0, 0, 0, 0.9);
@@ -197,6 +198,9 @@
 @media (max-width: 1250px) {
 	.uniHolder {
 		width: calc(100% - 6px);
+	}
+	.uniButton {
+		width: 10%;
 	}
 	.titleHolder {
 		width: 295px;

--- a/css/system-style.css
+++ b/css/system-style.css
@@ -70,32 +70,22 @@
 	width: 400px;
 	height: 7%;
 	display: flex;
-	justify-content: left;
-	align-items: center;
+	flex-direction: row;
+	flex-wrap: nowrap;
+	overflow-x: scroll;
+	scroll-behavior: smooth;
+  	-webkit-overflow-scrolling: touch;
+	white-space: nowrap;
 	background: #0f0f0f;
-	overflow: hidden;
 	border: 3px solid #7a7a7a;
 	z-index: 1000;
 }
-.miscMenu {
-	position: absolute;
-	bottom: 1px;
-	left: 0px;
-	width: 400px;
-	height: 7%;
-	display: flex;
-	flex-direction: row;
-	justify-content: auto;
-	background: #0f0f0f;
-	border-left: 3px solid #7a7a7a;
-	border-right: 3px solid #7a7a7a;
-	border-bottom: 3px solid #7a7a7a;
-	z-index: 1000;
-}
 .uniButton {
-	width: auto;
+	display: inline-block;
+  	flex: 0 0 auto;
+	margin: 0;
+	width: 19%;
 	height: 100%;
-	flex-grow: 1;
 	color: rgba(0, 0, 0, 0.9);
 	font-size: 3vh;
 	cursor: pointer;
@@ -135,6 +125,21 @@
 	color: rgba(255, 255, 255, 0.3);
 	background-color: #222;
 	cursor: default;
+}
+.miscMenu {
+	position: absolute;
+	bottom: 1px;
+	left: 0px;
+	width: 400px;
+	height: 7%;
+	display: flex;
+	flex-direction: row;
+	justify-content: auto;
+	background: #0f0f0f;
+	border-left: 3px solid #7a7a7a;
+	border-right: 3px solid #7a7a7a;
+	border-bottom: 3px solid #7a7a7a;
+	z-index: 1000;
 }
 .miscButton {
 	width: 60px;

--- a/index.html
+++ b/index.html
@@ -40,18 +40,14 @@
 	<div id="app">
 		<div class="uiHolder" v-if="!player.hideMenu" v-bind:style="!player.startedGame || player.tab == 'c' ?{'left':'-110%'}:{'left':'0px'}">
 			<div class="uniHolder">
-				<button class="uniButton" v-if="layerShown('i') && player.uniTab==1" v-bind:style="constructUniButtonStyle('i') " onclick="player.universe=1"><span class="buttonText">1</span></button>
-				<button class="uniButton" v-if="layerShown('h') && player.uniTab==0" v-bind:style="constructUniButtonStyle('h') " onclick="player.universe=-666"><span class="buttonText">H</span></button>
- 				<button class="uniButton" v-if="layerShown('in') && player.uniTab==1" v-bind:style="constructUniButtonStyle('in') " onclick="player.universe=2"><span class="buttonText">2</span></button>
- 				<button class="uniButton" v-if="layerShown('cp') && player.uniTab==2" v-bind:style="constructUniButtonStyle('cp') " onclick="player.universe=1.5"><span class="buttonText">A1</span></button>
- 				<button class="uniButton" v-if="layerShown('s') && player.uniTab==1" v-bind:style="constructUniButtonStyle('s') " onclick="player.universe=3"><span class="buttonText">3</span></button>
-				<button class="uniButton" v-if="layerShown('ch') && player.uniTab==1" v-bind:style="constructUniButtonStyle('ch') " onclick="player.universe=-0.5"><span class="buttonText">γ</span></button>
- 				<button class="uniButton" v-if="layerShown('du') && player.uniTab==1" v-bind:style="constructUniButtonStyle('du') " onclick="player.universe=-0.1"><span class="buttonText">D1</span></button>
-				<button class="uniButton" v-if="layerShown('au2') && player.uniTab==2" v-bind:style="constructUniButtonStyle('au2') " onclick="player.universe=2.5"><span class="buttonText">A2</span></button>
-				<div class="arrowHolder">
-					<button v-bind:class="{arrowButton:true,darkButton:player.sma.inStarmetalChallenge}" onclick="player.uniTab = player.uniTab-1" :disabled="player.uniTab<=player.minUniTab" style="border-bottom:1.5px solid"><span class="buttonText">▲</span></button>
-					<button v-bind:class="{arrowButton:true,darkButton:player.sma.inStarmetalChallenge}" onclick="player.uniTab = player.uniTab+1" :disabled="player.uniTab>=player.maxUniTab" style="border-top:1.5px solid"><span class="buttonText">▼</span></button>
-				</div>
+				<button class="uniButton" v-if="layerShown('i')" v-bind:style="constructUniButtonStyle('i') " onclick="player.universe=1"><span class="buttonText">1</span></button>
+				<button class="uniButton" v-if="layerShown('h')" v-bind:style="constructUniButtonStyle('h') " onclick="player.universe=-666"><span class="buttonText">H</span></button>
+ 				<button class="uniButton" v-if="layerShown('in')" v-bind:style="constructUniButtonStyle('in') " onclick="player.universe=2"><span class="buttonText">2</span></button>
+ 				<button class="uniButton" v-if="layerShown('cp')" v-bind:style="constructUniButtonStyle('cp') " onclick="player.universe=1.5"><span class="buttonText">A1</span></button>
+				<button class="uniButton" v-if="layerShown('au2')" v-bind:style="constructUniButtonStyle('au2') " onclick="player.universe=2.5"><span class="buttonText">A2</span></button>
+ 				<button class="uniButton" v-if="layerShown('s')" v-bind:style="constructUniButtonStyle('s') " onclick="player.universe=3"><span class="buttonText">3</span></button>
+ 				<button class="uniButton" v-if="layerShown('du')" v-bind:style="constructUniButtonStyle('du') " onclick="player.universe=-0.1"><span class="buttonText">D1</span></button>
+				<button class="uniButton" v-if="layerShown('ch')" v-bind:style="constructUniButtonStyle('ch') " onclick="player.universe=-0.5"><span class="buttonText">γ</span></button>
 			</div>
 			<div class="layerHolder">
 				<div v-bind:class="{titleHolder:true,darkTitle:player.sma.inStarmetalChallenge}">

--- a/js/AltU2/altUni2.js
+++ b/js/AltU2/altUni2.js
@@ -57,5 +57,5 @@ addLayer("au2", {
         ["raw-html", function () { return "You will gain " + formatWhole(player.au2.starsToGet) + " stars on reset." }, { "color": "white", "font-size": "20px", "font-family": "monospace" }],
         ["microtabs", "stuff", { 'border-width': '0px' }],
     ],
-    layerShown() { return player.startedGame == true && player.au2.au2Unlocked}
+    layerShown() { return player.startedGame == true && player.au2.au2Unlocked && !player.sma.inStarmetalChallenge}
 })

--- a/js/Cantepocalypse/funify.js
+++ b/js/Cantepocalypse/funify.js
@@ -2505,7 +2505,7 @@
             "Fear": {
                 content: [
                     ["row", [
-                        ["raw-html", () => {return "You have <h3>" + format(player.fu.fear) + "</h3> anger"}, {color: "gray", fontSize: "24px", fontFamily: "monospace"}],
+                        ["raw-html", () => {return "You have <h3>" + format(player.fu.fear) + "</h3> fear"}, {color: "gray", fontSize: "24px", fontFamily: "monospace"}],
                         ["raw-html", () => {return "(+" + format(player.fu.fearPerSecond) + "/s)"}, () => {
                             let look = {fontSize: "24px", fontFamily: "monospace", marginLeft: "10px"}
                             if (player.fu.fearProduce && inChallenge("fu", 11)) {look.color = "gray"} else {look.color = "#222"}

--- a/js/Check Back/pet.js
+++ b/js/Check Back/pet.js
@@ -70,6 +70,7 @@ addLayer("pet", {
         //leg
         legendaryPetAbilityTimers: [new Decimal(0),],
         legendaryPetAbilityTimersMax: [new Decimal(600),],
+        eclipsePity: 0,
 
         activeAbilities: [false,],
     }},
@@ -462,7 +463,7 @@ addLayer("pet", {
         15: {
             title() { return "Legendary Gems" },
             canClick() { return true },
-            unlocked() { return player.cb.legendaryPetGems[0].gt(0) || player.cb.legendaryPetGems[1].gt(0) || player.cb.legendaryPetGems[2].gt(0) },
+            unlocked() { return player.cb.highestLevel.gte(25000) && hasUpgrade("s", 23) },
             onClick() {
                 player.subtabs["pet"]["content"] = "Legendary Gems"
             },
@@ -728,7 +729,7 @@ addLayer("pet", {
             title() { return player.pet.summonTimer.gt(0) ? "<h3>Check back in <br>" + formatTime(player.pet.summonTimer) + "." : "SUMMON."},
             canClick() { return player.pet.summonTimer.lte(0) && player.cb.legendaryPetGems[0].gte(player.pet.summonReqs[0]) && player.cb.legendaryPetGems[1].gte(player.pet.summonReqs[1]) && player.cb.legendaryPetGems[2].gte(player.pet.summonReqs[2]) && player.cb.evolutionShards.gte(player.pet.summonReqs[3]) && player.cb.paragonShards.gte(player.pet.summonReqs[4]) },
             unlocked() { return true },
-            tooltip() { return "25% - 14 of every common pet<br>25% - 10 of every uncommon pet<br>15% - 4 of every rare pet<br>10% - Epic pet and singularity fragments<br>10% - A lot of pet points<br>15% - LEGENDARY PET SUMMON" },
+            tooltip() { return "20% - 14 of every common pet<br>20% - 10 of every uncommon pet<br>20% - 4 of every rare pet<br>10% - Epic pet and singularity fragments<br>10% - A lot of pet points<br>20% - LEGENDARY PET SUMMON" },
             onClick() {
                 player.cb.legendaryPetGems[0] = player.cb.legendaryPetGems[0].sub(player.pet.summonReqs[0])
                 player.cb.legendaryPetGems[1] = player.cb.legendaryPetGems[1].sub(player.pet.summonReqs[1])
@@ -3274,19 +3275,11 @@ addLayer("pet", {
             layers.cb.petButton7()
         } else if (rng < 0.02) {
             let random = getRandomInt(3)
-            let gainedGems = getRandomInt(5) + 6
-            if (random == 0) {
-                player.cb.legendaryPetGems[0] = player.cb.legendaryPetGems[0].add(gainedGems);
-                callAlert("You gained " + formatWhole(gainedGems) + " Red Legendary Gems!", "resources/redLegendaryPetGem.png");
-            }
-            if (random == 1) {
-                player.cb.legendaryPetGems[1] = player.cb.legendaryPetGems[1].add(gainedGems);
-                callAlert("You gained " + formatWhole(gainedGems) + " Purple Legendary Gems!", "resources/purpleLegendaryPetGem.png");
-            }
-            if (random == 2) {
-                player.cb.legendaryPetGems[2] = player.cb.legendaryPetGems[2].add(gainedGems);
-                callAlert("You gained " + formatWhole(gainedGems) + " Green Legendary Gems!", "resources/greenLegendaryPetGem.png");
-            }
+            let gainedGems = getRandomInt(5) + 10
+            player.cb.legendaryPetGems[0] = player.cb.legendaryPetGems[0].add(gainedGems);
+            player.cb.legendaryPetGems[1] = player.cb.legendaryPetGems[1].add(gainedGems);
+            player.cb.legendaryPetGems[2] = player.cb.legendaryPetGems[2].add(gainedGems);
+            callAlert("You gained " + formatWhole(gainedGems) + " of each Legendary Gem!", "resources/Pets/legendarybg.png");
         }
     },
     resetPrices() {
@@ -3297,8 +3290,14 @@ addLayer("pet", {
         player.pet.crateBought = [0, 0, 0, 0, 0, 0]
     },
     legendarySummon() {
+        if (player.pet.eclipsePity == 4) {
+            player.pet.levelables[501][1] = player.pet.levelables[501][1].add(1)
+            callAlert("Eclipse becomes stronger. (PITY ROLL)", "resources/Pets/eclipseLegendaryPet.png"); //Make sure to change this when you add more legendary pets
+            player.pet.eclipsePity = 0
+            return
+        }
         let random = Math.random();
-        if (random < 0.25) {
+        if (random < 0.2) {
             player.pet.levelables[101][1] = player.pet.levelables[101][1].add(14)
             player.pet.levelables[102][1] = player.pet.levelables[101][1].add(14)
             player.pet.levelables[103][1] = player.pet.levelables[101][1].add(14)
@@ -3308,8 +3307,9 @@ addLayer("pet", {
             player.pet.levelables[107][1] = player.pet.levelables[107][1].add(14)
             player.pet.levelables[108][1] = player.pet.levelables[108][1].add(14)
             player.pet.levelables[109][1] = player.pet.levelables[109][1].add(14)
-            callAlert("You gained 14 of every common pet!", "resources/Pets/commonbg.png");
-        } else if (random < 0.5) {
+            callAlert("You gained 14 of every common pet!", "resources/Pets/commonbg.png")
+            player.pet.eclipsePity = player.pet.eclipsePity + 1
+        } else if (random < 0.4) {
             player.pet.levelables[201][1] = player.pet.levelables[201][1].add(10)
             player.pet.levelables[202][1] = player.pet.levelables[202][1].add(10)
             player.pet.levelables[203][1] = player.pet.levelables[203][1].add(10)
@@ -3319,8 +3319,9 @@ addLayer("pet", {
             player.pet.levelables[207][1] = player.pet.levelables[207][1].add(10)
             player.pet.levelables[208][1] = player.pet.levelables[208][1].add(10)
             player.pet.levelables[209][1] = player.pet.levelables[209][1].add(10)
-            callAlert("You gained 10 of every uncommon pet!", "resources/Pets/uncommonbg.png");
-        } else if (random < 0.65) {
+            callAlert("You gained 10 of every uncommon pet!", "resources/Pets/uncommonbg.png")
+            player.pet.eclipsePity = player.pet.eclipsePity + 1
+        } else if (random < 0.6) {
             player.pet.levelables[301][1] = player.pet.levelables[301][1].add(4)
             player.pet.levelables[302][1] = player.pet.levelables[302][1].add(4)
             player.pet.levelables[303][1] = player.pet.levelables[303][1].add(4)
@@ -3330,28 +3331,48 @@ addLayer("pet", {
             player.pet.levelables[307][1] = player.pet.levelables[307][1].add(4)
             player.pet.levelables[308][1] = player.pet.levelables[308][1].add(4)
             player.pet.levelables[309][1] = player.pet.levelables[309][1].add(4)
-            callAlert("You gained 4 of every rare pet!", "resources/Pets/rarebg.png");
-        } else if (random < 0.75) {
+            callAlert("You gained 4 of every rare pet!", "resources/Pets/rarebg.png")
+            player.pet.eclipsePity = player.pet.eclipsePity + 1
+        } else if (random < 0.7) {
             let random2 = getRandomInt(6, 10)
             player.pet.singularityFragments = player.pet.singularityFragments.add(random2)
             addLevelableXP("pet", 401, random2)
             addLevelableXP("pet", 402, random2)
             addLevelableXP("pet", 403, random2)
 
-            callAlert("You gained " + random2 + " of every epic and singularity fragment!", "resources/Pets/epicbg.png");
-
-        } else if (random < 0.9) {
-            let random3 = getRandomInt(1000, 2000)
+            callAlert("You gained " + random2 + " of every epic and singularity fragment!", "resources/Pets/epicbg.png")
+            player.pet.eclipsePity = player.pet.eclipsePity + 1
+        } else if (random < 0.8) {
+            let random3 = getRandomInt(5000, 10000)
             random3 = random3 * player.pet.petPointMult
 
             player.cb.petPoints = player.cb.petPoints.add(random3)
-            callAlert("You gained " + formatWhole(random3) + " pet points!", "resources/petPoint.png");
+            callAlert("You gained " + formatWhole(random3) + " pet points!", "resources/petPoint.png")
+            player.pet.eclipsePity = player.pet.eclipsePity + 1
         } else {
             player.pet.levelables[501][1] = player.pet.levelables[501][1].add(1)
             callAlert("Eclipse becomes stronger.", "resources/Pets/eclipseLegendaryPet.png"); //Make sure to change this when you add more legendary pets
         }
     },
-    bars: {},
+    bars: {
+        summonPity: {
+            unlocked: true,
+            direction: RIGHT,
+            width: 300,
+            height: 50,
+            progress() {
+                return new Decimal(player.pet.eclipsePity / 5)
+            },
+            borderStyle: {border: "2px solid white", borderRadius: "15px"},
+            baseStyle: {backgroundColor: "#2f2a00"},
+            fillStyle: {
+                "background-color": "#776900",
+            },
+            display() {
+                return "<h5>" + player.pet.eclipsePity + "/5<br>Legendary Summon Pity</h5>";
+            },
+        },
+    },
     upgrades: {},
     buyables: {},
     milestones: {},
@@ -3548,6 +3569,8 @@ addLayer("pet", {
                             ], {width: "300px", height: "50px", backgroundColor: "black", borderLeft: "2px solid white", borderRight: "2px solid white", borderBottom: "2px solid white", borderRadius: "0 0 10px 10px", userSelect: "none"}],
                             ["blank", "25px"],
                             ["row", [["clickable", 202]]],
+                            ["blank", "10px"],
+                            ["bar", "summonPity"],
                         ], () => {return player.cb.highestLevel.gte(100000) ? {width: "500px", border: "3px solid rgb(27, 0, 36)", backgroundColor: "#f5b942", paddingTop: "5px", paddingBottom: "20px", borderRadius: "15px"} : {display: "none !important"}}],
                     ], {width: "550px", height: "700px", backgroundColor: "#eed200"}],
                 ],

--- a/js/Check Back/pet.js
+++ b/js/Check Back/pet.js
@@ -70,8 +70,6 @@ addLayer("pet", {
         //leg
         legendaryPetAbilityTimers: [new Decimal(0),],
         legendaryPetAbilityTimersMax: [new Decimal(600),],
-        legendaryPetAbilityCooldowns: [new Decimal(0),],
-        legendaryPetAbilityCooldownsMax: [new Decimal(36000),],
 
         activeAbilities: [false,],
     }},
@@ -234,10 +232,6 @@ addLayer("pet", {
         player.pet.cratePrices[5] = player.pet.cratePrices[5].add(new Decimal(250).mul(player.pet.crateBought[5]))
 
         //legendary pets
-        player.pet.legendaryPetAbilityCooldownsMax = [new Decimal(36000),]
-        for (let i = 0; i < player.pet.legendaryPetAbilityCooldownsMax.length; i++) {
-            player.pet.legendaryPetAbilityCooldowns[i] = player.pet.legendaryPetAbilityCooldowns[i].sub(onepersec.mul(delta))
-        }
 
         player.pet.legendaryPetAbilityTimersMax = [new Decimal(600),]
         player.pet.legendaryPetAbilityTimersMax[0] = player.pet.legendaryPetAbilityTimersMax[0].mul(levelableEffect("pu", 303)[1])
@@ -517,15 +511,12 @@ addLayer("pet", {
 
         //legendary pet skills
         31: {
-            title() { return player.pet.legendaryPetAbilityCooldowns[0].lte(0) ? "<h3>Activate Skill" : 
-                player.pet.legendaryPetAbilityTimers[0].lte(0) ? "Check back in " + formatTime(player.pet.legendaryPetAbilityCooldowns[0]) + "." 
-                : "<h3>Skill Active<br>for " + formatTime(player.pet.legendaryPetAbilityTimers[0]) + "."},
+            title: "<h3>Activate Skill</h3>",
             tooltip() { return "Activates the eclipse in DU1 for 10 minutes, unlocking alternate gameplay mechanics. (Also throws you into DU1 cause why not)"},
-            canClick() { return player.pet.legendaryPetAbilityCooldowns[0].lte(0) },
+            canClick: true,
             unlocked() { return layers.pet.levelables.index == 501 },
             onClick () {
                 player.pet.legendaryPetAbilityTimers[0] = player.pet.legendaryPetAbilityTimersMax[0]
-                player.pet.legendaryPetAbilityCooldowns[0] = player.pet.legendaryPetAbilityCooldownsMax[0]
                 player.pet.activeAbilities[0] = true
 
                 player.sma.inStarmetalChallenge = true
@@ -539,12 +530,7 @@ addLayer("pet", {
                 player.subtabs.le["stuff"] = "Shards"
                 player.subtabs.pu["stuff"] = "Selection"                
             },
-            style() {
-                let look = {width: '125px', minHeight: '40px', borderRadius: '0px', fontSize: '8px'}
-                this.canClick() ? look.backgroundColor = "#eed200" : look.backgroundColor = "#bf8f8f"
-                this.canClick() ? look.color = "black" : look.color = "black"
-                return look
-            },
+            style: {width: '125px', minHeight: '40px', backgroundColor: "#eed200", color: "black", borderRadius: '0px', fontSize: '8px'},
         },
         
         // START OF FRAGMENTATION CLICKABLES

--- a/js/Hex/blessings.js
+++ b/js/Hex/blessings.js
@@ -154,7 +154,7 @@ addLayer("hbl", {
         2: {
             title() {
                 let str = "<h3>Hex Point Booster <small>Lv." + formatWhole(player.hbl.boosterLevels[0]) + "</small></h3><br>(" + formatWhole(player.hbl.boosterXP[0]) + "/" + formatWhole(player.hbl.boosterReq[0]) + ")<br>x" + format(player.hbl.boosterEffects[0]) + " Hex Points<br><small>(Hold to deposit boons)</small>"
-                if (player.hbl.boosterEffects[0].pow(Decimal.div(1, player.hpu.purifierEffects[3])).gte(1e9)) str = str.concat("<br><small style='color:darkred'>[SOFTLOCKED]</small>")
+                if (player.hbl.boosterEffects[0].pow(Decimal.div(1, player.hpu.purifierEffects[3])).gte(1e9)) str = str.concat("<br><small style='color:darkred'>[SOFTCAPPED]</small>")
                 return str
             },
             canClick: true,
@@ -200,7 +200,7 @@ addLayer("hbl", {
         4: {
             title() {
                 let str = "<h3>IP Booster <small>Lv." + formatWhole(player.hbl.boosterLevels[2]) + "</small></h3><br>(" + formatWhole(player.hbl.boosterXP[2]) + "/" + formatWhole(player.hbl.boosterReq[2]) + ")<br>x" + format(player.hbl.boosterEffects[2]) + " Infinity Points<br><small>(Hold to deposit boons)</small>"
-                if (player.hbl.boosterEffects[2].gte(1e9)) str = str.concat("<br><small style='color:darkred'>[SOFTLOCKED]</small>")
+                if (player.hbl.boosterEffects[2].gte(1e9)) str = str.concat("<br><small style='color:darkred'>[SOFTCAPPED]</small>")
                 return str
             },
             canClick: true,
@@ -225,7 +225,7 @@ addLayer("hbl", {
         5: {
             title() {
                 let str = "<h3>Refiner Req Booster <small>Lv." + formatWhole(player.hbl.boosterLevels[3]) + "</small></h3><br>(" + formatWhole(player.hbl.boosterXP[3]) + "/" + formatWhole(player.hbl.boosterReq[3]) + ")<br>/" + format(player.hbl.boosterEffects[3]) + " Refinement Req<br><small>(Hold to deposit boons)</small>"
-                if (player.hbl.boosterEffects[3].gte(1e12)) str = str.concat("<br><small style='color:darkred'>[SOFTLOCKED]</small>")
+                if (player.hbl.boosterEffects[3].gte(1e12)) str = str.concat("<br><small style='color:darkred'>[SOFTCAPPED]</small>")
                 return str
             },
             canClick: true,
@@ -271,7 +271,7 @@ addLayer("hbl", {
         7: {
             title() {
                 let str = "<h3>IP Booster Booster <small>Lv." + formatWhole(player.hbl.boosterLevels[5]) + "</small></h3><br>(" + formatWhole(player.hbl.boosterXP[5]) + "/" + formatWhole(player.hbl.boosterReq[5]) + ")<br>x" + format(player.hbl.boosterEffects[5]) + " IP Booster Base<br><small>(Hold to deposit boons)</small>"
-                if (player.hbl.boosterEffects[5].gte(16)) str = str.concat("<br><small style='color:darkred'>[SOFTLOCKED]</small>")
+                if (player.hbl.boosterEffects[5].gte(16)) str = str.concat("<br><small style='color:darkred'>[SOFTCAPPED]</small>")
                 return str
             },
             canClick: true,

--- a/js/Hex/curses.js
+++ b/js/Hex/curses.js
@@ -13,7 +13,7 @@ addLayer("hcu", {
         jinxDiv: new Decimal(1),
     }},
     automate() {
-        if (hasMilestone("hre", 17) && !inChallenge("hrm", 15)) {
+        if (hasMilestone("hre", 13) && !inChallenge("hrm", 15)) {
             for (let i = 101; i < 113; i++) {
                 buyMaxExBuyable("hcu", i)
             }
@@ -115,7 +115,7 @@ addLayer("hcu", {
             total() { return "(Total: " + format(tmp[this.layer].buyables[this.id].effect) + "x)" },
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -123,7 +123,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(60)) max = Decimal.affordGeometricSeries(this.currency().mul(1e6).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(60).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }
@@ -163,7 +163,7 @@ addLayer("hcu", {
             total() { return "(Total: +" + format(tmp[this.layer].buyables[this.id].effect) + "x)" },
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -171,7 +171,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(60)) max = Decimal.affordGeometricSeries(this.currency().mul(1e50).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(60).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }
@@ -203,7 +203,7 @@ addLayer("hcu", {
             total() { return "(Total: " + format(tmp[this.layer].buyables[this.id].effect) + "x)"},
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -211,7 +211,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(60)) max = Decimal.affordGeometricSeries(this.currency().mul(1e135).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(60).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }
@@ -243,7 +243,7 @@ addLayer("hcu", {
             total() { return "(Total: " + format(tmp[this.layer].buyables[this.id].effect) + "x)"},
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -251,7 +251,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(40)) max = Decimal.affordGeometricSeries(this.currency().mul(1e95).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(40).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }
@@ -287,7 +287,7 @@ addLayer("hcu", {
             total() {return "(Total: " + format(tmp[this.layer].buyables[this.id].effect) + "x)"},
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -295,7 +295,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(30)) max = Decimal.affordGeometricSeries(this.currency().mul(1e125).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(30).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }
@@ -322,7 +322,7 @@ addLayer("hcu", {
             total() { return "(Total: ^" + format(tmp[this.layer].buyables[this.id].effect) + ")"},
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -330,7 +330,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(20)) max = Decimal.affordGeometricSeries(this.currency().mul(1e215).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(20).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }
@@ -370,7 +370,7 @@ addLayer("hcu", {
             },
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -378,7 +378,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(60)) max = Decimal.affordGeometricSeries(this.currency().mul(1e50).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(60).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }
@@ -418,7 +418,7 @@ addLayer("hcu", {
             },
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -426,7 +426,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(40)) max = Decimal.affordGeometricSeries(this.currency().mul(1e105).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(40).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }
@@ -469,7 +469,7 @@ addLayer("hcu", {
             },
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -477,7 +477,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(30)) max = Decimal.affordGeometricSeries(this.currency().mul(1e125).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(30).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }
@@ -513,7 +513,7 @@ addLayer("hcu", {
             total() { return "(Total: +" + format(tmp[this.layer].buyables[this.id].effect) + "x)"},
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -521,7 +521,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(10)) max = Decimal.affordGeometricSeries(this.currency().mul(1e260).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(10).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }
@@ -556,7 +556,7 @@ addLayer("hcu", {
             total() { return "(Total: +" + format(tmp[this.layer].buyables[this.id].effect) + "x)"},
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -564,7 +564,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(12)) max = Decimal.affordGeometricSeries(this.currency().mul(1e200).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(12).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }
@@ -600,7 +600,7 @@ addLayer("hcu", {
             total() { return "(Total: +" + format(tmp[this.layer].buyables[this.id].effect) + "x)"},
             buy(mult) {
                 if (mult != true) {
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(this.cost())
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(this.cost())
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(1))
                 } else {
                     let max = Decimal.affordGeometricSeries(this.currency(), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
@@ -608,7 +608,7 @@ addLayer("hcu", {
                     if (max.add(getBuyableAmount(this.layer, this.id)).gte(16)) max = Decimal.affordGeometricSeries(this.currency().mul(1e140).pow(Decimal.div(1, 3)), this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id)).max(new Decimal(16).sub(getBuyableAmount(this.layer, this.id)))
                     if (max.gt(this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)))) { max = this.purchaseLimit().sub(getBuyableAmount(this.layer, this.id)) }
                     let cost = Decimal.sumGeometricSeries(max, this.costBase(), this.costGrowth(), getBuyableAmount(this.layer, this.id))
-                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 17)) this.pay(cost)
+                    if (!hasMilestone("hpw", 5) && !hasMilestone("hre", 13)) this.pay(cost)
 
                     setBuyableAmount(this.layer, this.id, getBuyableAmount(this.layer, this.id).add(max))
                 }

--- a/js/Hex/provenance.js
+++ b/js/Hex/provenance.js
@@ -237,9 +237,9 @@ addLayer("hpr", {
                             player.hpr.rankGain[0].gt(0) ? look.color = "white" : look.color = "gray"
                             return look
                         }],
-                        ["raw-html", () => {return player.hpr.rank[0].gte(1200) && player.hpr.rank[0].lt(6000000) ? "[SOFTLOCKED]" : ""}, {color: "red", fontSize: "14px", fontFamily: "monospace", marginLeft: "5px"}],
-                        ["raw-html", () => {return player.hpr.rank[0].gte(6000000) && player.hpr.rank[0].lt(2.4e8) ? "[SOFTLOCKED<sup>2</sup>]" : ""}, {color: "red", fontSize: "14px", fontFamily: "monospace", marginLeft: "5px"}],
-                        ["raw-html", () => {return player.hpr.rank[0].gte(2.4e8) ? "[SOFTLOCKED<sup>3</sup>]" : ""}, {color: "red", fontSize: "14px", fontFamily: "monospace", marginLeft: "5px"}],
+                        ["raw-html", () => {return player.hpr.rank[0].gte(1200) && player.hpr.rank[0].lt(6000000) ? "[SOFTCAPPED]" : ""}, {color: "red", fontSize: "14px", fontFamily: "monospace", marginLeft: "5px"}],
+                        ["raw-html", () => {return player.hpr.rank[0].gte(6000000) && player.hpr.rank[0].lt(2.4e8) ? "[SOFTCAPPED<sup>2</sup>]" : ""}, {color: "red", fontSize: "14px", fontFamily: "monospace", marginLeft: "5px"}],
+                        ["raw-html", () => {return player.hpr.rank[0].gte(2.4e8) ? "[SOFTCAPPED<sup>3</sup>]" : ""}, {color: "red", fontSize: "14px", fontFamily: "monospace", marginLeft: "5px"}],
                     ]],
                 ], {width: "250px", height: "50px", borderBottom: "2px solid white"}],
                 ["style-column", [

--- a/js/Hex/purity.js
+++ b/js/Hex/purity.js
@@ -28,7 +28,7 @@ addLayer("hpu", {
 
         if (player.hpu.purityGain.lt(1)) player.hpu.purityGain = new Decimal(0)
 
-        if (hasMilestone("hre", 15) && !inChallenge("hrm", 15)) {
+        if (hasMilestone("hre", 17) && !inChallenge("hrm", 15)) {
             player.hpu.purity = player.hpu.purity.add(player.hpu.purityGain)
             player.hpu.totalPurity = player.hpu.totalPurity.add(player.hpu.purityGain)
         }
@@ -73,11 +73,11 @@ addLayer("hpu", {
                 if (inChallenge("hrm", 16)) return "<h2>Purify, but reset hex points and refinement.</h2><br><h3>Req: " + formatWhole(player.hpu.purityReq) + " Refinements</h3>"
                 return "<h2>Purify, but reset hex points, provenance, and refinement.</h2><br><h3>Req: " + formatWhole(player.hpu.purityReq) + " Refinements</h3>"
             },
-            canClick() { return player.hpu.purityGain.gte(1) && (!hasMilestone("hre", 15) || inChallenge("hrm", 15))},
+            canClick() { return player.hpu.purityGain.gte(1) && (!hasMilestone("hre", 17) || inChallenge("hrm", 15))},
             unlocked: true,
             onClick() {
                 let amt = new Decimal(1)
-                if (hasMilestone("hre", 13)) amt = player.hpu.purityGain
+                if (hasMilestone("hre", 15)) amt = player.hpu.purityGain
                 player.hpu.purity = player.hpu.purity.add(amt)
                 player.hpu.totalPurity = player.hpu.totalPurity.add(amt)
 
@@ -95,7 +95,7 @@ addLayer("hpu", {
             },
             style() {
                 let look = {width: "400px", minHeight: "100px", border: "2px solid black", borderRadius: "15px"}
-                if (hasMilestone("hre", 15) && !inChallenge("hrm", 15)) look.cursor = "default !important"
+                if (hasMilestone("hre", 17) && !inChallenge("hrm", 15)) look.cursor = "default !important"
                 return look
             },
         },
@@ -263,7 +263,7 @@ addLayer("hpu", {
         ["blank", "10px"],
         ["row", [
             ["raw-html", () => {return "You have <h3>" + formatWhole(player.hpu.purity) + "</h3> purity." }, {color: "white", fontSize: "24px", fontFamily: "monospace"}],
-            ["raw-html", () => {return hasMilestone("hre", 13) ? "(+" + formatWhole(player.hpu.purityGain) + ")" : "" }, () => {
+            ["raw-html", () => {return hasMilestone("hre", 15) ? "(+" + formatWhole(player.hpu.purityGain) + ")" : "" }, () => {
                 let look = {color: "white", fontSize: "24px", fontFamily: "monospace", marginLeft: "10px"}
                 player.hpu.purityGain.gt(0) ? look.color = "white" : look.color = "gray"
                 return look

--- a/js/Hex/purity.js
+++ b/js/Hex/purity.js
@@ -118,7 +118,7 @@ addLayer("hpu", {
         3: {
             title() {
                 let str = "<h3>Purified Provenances</h3><br>Lv." + formatWhole(player.hpu.purifier[0]) + "<br>^" + format(player.hpu.purifierEffects[0]) + " Refiner 2's Effects"
-                if (player.hpu.purifierEffects[0].gt(1.5)) str = str.concat("<br><small style='color:darkred'>[SOFTLOCKED]</small>")
+                if (player.hpu.purifierEffects[0].gt(1.5)) str = str.concat("<br><small style='color:darkred'>[SOFTCAPPED]</small>")
                 return str
             },
             canClick() {return player.hpu.purity.gte(1)},
@@ -134,7 +134,7 @@ addLayer("hpu", {
             title() {
                 let str = "<h3>Multiplied Miracles</h3><br>Lv." + formatWhole(player.hpu.purifier[1]) + "<br>x" + format(player.hpu.purifierEffects[1]) + " 1st & 4th Miracles"
                 if (inChallenge("hrm", 12)) str = "<h3>Multiplied Miracles</h3><br>Lv." + formatWhole(player.hpu.purifier[1]) + "<br>x" + format(player.hpu.purifierEffects[1]) + " Blessings and Boons"
-                if (player.hpu.purifierEffects[1].gt(8)) str = str.concat("<br><small style='color:darkred'>[SOFTLOCKED]</small>")
+                if (player.hpu.purifierEffects[1].gt(8)) str = str.concat("<br><small style='color:darkred'>[SOFTCAPPED]</small>")
                 return str
             },
             canClick() {return player.hpu.purity.gte(1)},
@@ -149,7 +149,7 @@ addLayer("hpu", {
         5: {
             title() {
                 let str = "<h3>Elevated Exponent</h3><br>Lv." + formatWhole(player.hpu.purifier[2]) + "<br>^" + format(player.hpu.purifierEffects[2]) + " Non-Hex Refiner Effects"
-                if (player.hpu.purifierEffects[2].gt(1.5)) str = str.concat("<br><small style='color:darkred'>[SOFTLOCKED]</small>")
+                if (player.hpu.purifierEffects[2].gt(1.5)) str = str.concat("<br><small style='color:darkred'>[SOFTCAPPED]</small>")
                 return str
             },
             canClick() {return player.hpu.purity.gte(1) && !hasUpgrade("hpw", 101)},
@@ -172,7 +172,7 @@ addLayer("hpu", {
             title() {
                 let str = "<h3>Healed Hexes</h3><br>Lv." + formatWhole(player.hpu.purifier[3]) + "<br>^" + format(player.hpu.purifierEffects[3]) + " Hex Point Booster"
                 if (inChallenge("hrm", 12)) str = "<h3>Healed Hexes</h3><br>Lv." + formatWhole(player.hpu.purifier[3]) + "<br>^" + format(player.hpu.purifierEffects[3]) + " 1st Refiners Effects"
-                if (player.hpu.purifierEffects[3].gt(1.5)) str = str.concat("<br><small style='color:darkred'>[SOFTLOCKED]</small>")
+                if (player.hpu.purifierEffects[3].gt(1.5)) str = str.concat("<br><small style='color:darkred'>[SOFTCAPPED]</small>")
                 return str
             },
             canClick() {return player.hpu.purity.gte(1)},
@@ -188,7 +188,7 @@ addLayer("hpu", {
             title() {
                 let str = "<h3>Amended Automation</h3><br>Lv." + formatWhole(player.hpu.purifier[4]) + "<br>+" + formatWhole(player.hpu.purifierEffects[4].mul(100)) + "% blessings/s"
                 str = str.concat("<br><small>(" + format(player.hbl.blessingsGain.mul(player.hpu.purifierEffects[4])) + "/s)</small>")
-                if (player.hpu.purifierEffects[4].gt(3.2)) str = str.concat("<br><small style='color:darkred'>[SOFTLOCKED]</small>")
+                if (player.hpu.purifierEffects[4].gt(3.2)) str = str.concat("<br><small style='color:darkred'>[SOFTCAPPED]</small>")
                 if (inChallenge("hrm", 11)) str = str.concat("<br><small style='color:red'>[DISABLED BY CREATOR REALM]</small>")
                 return str
             },
@@ -209,7 +209,7 @@ addLayer("hpu", {
             title() {
                 let str = "<h3>Cleansed Curses</h3><br>Lv." + formatWhole(player.hpu.purifier[5]) + "<br>^" + format(player.hpu.purifierEffects[5]) + " 4th Grace Effect"
                 if (inChallenge("hrm", 12)) str = "<h3>Cleansed Curses</h3><br>Lv." + formatWhole(player.hpu.purifier[5]) + "<br>^" + format(player.hpu.purifierEffects[5]) + " Base Α-Jinx Effect"
-                if (player.hpu.purifierEffects[5].gt(1.75) || (inChallenge("hrm", 12) && player.hpu.purifierEffects[5].gt(1.5))) str = str.concat("<br><small style='color:darkred'>[SOFTLOCKED]</small>")
+                if (player.hpu.purifierEffects[5].gt(1.75) || (inChallenge("hrm", 12) && player.hpu.purifierEffects[5].gt(1.5))) str = str.concat("<br><small style='color:darkred'>[SOFTCAPPED]</small>")
                 return str
             },
             canClick() {return player.hpu.purity.gte(1)},

--- a/js/Hex/realms.js
+++ b/js/Hex/realms.js
@@ -70,7 +70,7 @@ addLayer("hrm", {
     buyables: {
         1: {
             costBase() { return new Decimal(1) },
-            costGrowth() { return new Decimal(10) },
+            costGrowth() { return new Decimal(6) },
             purchaseLimit() { return new Decimal(12) },
             currency() { return player.hrm.realmEssence},
             pay(amt) { player.hrm.realmEssence = this.currency().sub(amt) },
@@ -155,7 +155,7 @@ addLayer("hrm", {
         },
         4: {
             costBase() { return new Decimal(1000) },
-            costGrowth() { return new Decimal(25) },
+            costGrowth() { return new Decimal(12) },
             purchaseLimit() { return new Decimal(60) },
             currency() { return player.hrm.realmEssence},
             pay(amt) { player.hrm.realmEssence = this.currency().sub(amt) },
@@ -184,7 +184,7 @@ addLayer("hrm", {
         },
         5: {
             costBase() { return new Decimal(10000) },
-            costGrowth() { return new Decimal(50) },
+            costGrowth() { return new Decimal(24) },
             purchaseLimit() { return new Decimal(20) },
             currency() { return player.hrm.realmEssence},
             pay(amt) { player.hrm.realmEssence = this.currency().sub(amt) },
@@ -213,7 +213,7 @@ addLayer("hrm", {
         },
         6: {
             costBase() { return new Decimal(100000) },
-            costGrowth() { return new Decimal(100) },
+            costGrowth() { return new Decimal(60) },
             purchaseLimit() { return new Decimal(30) },
             currency() { return player.hrm.realmEssence},
             pay(amt) { player.hrm.realmEssence = this.currency().sub(amt) },

--- a/js/Hex/refinement.js
+++ b/js/Hex/refinement.js
@@ -207,7 +207,7 @@ addLayer("hre", {
         },
         13: {
             requirementDescription: "<h3>90 Refinements",
-            effectDescription: "Unlock buy max purity.",
+            effectDescription: "Automate jinxes.",
             done() { return player.hre.refinement.gte(90)},
             unlocked() { return hasMilestone("hre", 12) },
             style: {width: "500px", height: "50px", color: "rgba(0,0,0,0.5)", border: "5px solid rgba(0,0,0,0.5)", borderRadius: "10px", margin: "-2.5px"},
@@ -224,7 +224,7 @@ addLayer("hre", {
         },
         15: {
             requirementDescription: "<h3>102 Refinements",
-            effectDescription: "Automate purity gain.",
+            effectDescription: "Unlock buy max purity.",
             done() { return player.hre.refinement.gte(102)},
             unlocked() { return hasMilestone("hre", 14) },
             style: {width: "500px", height: "50px", color: "rgba(0,0,0,0.5)", border: "5px solid rgba(0,0,0,0.5)", borderRadius: "10px", margin: "-2.5px"},
@@ -238,7 +238,7 @@ addLayer("hre", {
         },
         17: {
             requirementDescription: "<h3>114 Refinements",
-            effectDescription: "Automate jinxes.",
+            effectDescription: "Automate purity gain.",
             done() { return player.hre.refinement.gte(114)},
             unlocked() { return hasMilestone("hre", 16) },
             style: {width: "500px", height: "50px", color: "rgba(0,0,0,0.5)", border: "5px solid rgba(0,0,0,0.5)", borderRadius: "10px", margin: "-2.5px"},

--- a/js/Singularity/singularity.js
+++ b/js/Singularity/singularity.js
@@ -64,7 +64,7 @@ addLayer("s", {
 
         player.s.singularityTime = player.s.singularityTime.add(onepersec.mul(delta))
 
-        player.s.singularitiesEffect = Decimal.pow(1.175, player.s.singularities.add(1).log(10))
+        player.s.singularitiesEffect = Decimal.pow(1.2, player.s.singularities.add(1).log(10))
     },
     clickables: {},
     bars: {},

--- a/js/Singularity/starmetalAlloy.js
+++ b/js/Singularity/starmetalAlloy.js
@@ -75,7 +75,6 @@
             unlocked: true,
             onClick() {
                 player.pet.legendaryPetAbilityTimers[0] = player.pet.legendaryPetAbilityTimersMax[0]
-                player.pet.legendaryPetAbilityCooldowns[0] = player.pet.legendaryPetAbilityCooldownsMax[0]
                 player.pet.activeAbilities[0] = true
 
                 player.sma.inStarmetalChallenge = true

--- a/js/checkback.js
+++ b/js/checkback.js
@@ -2402,8 +2402,14 @@ addLayer("cb", {
                 return "Check Back OTF Boost."
             },
             display() {
-                return "which are multiplying hex points, rocket fuel, and dice points by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels worth of XP."
+                if (tmp[this.layer].buyables[this.id].cost.gte(player.cb.totalxp)) {
+                    return "which are multiplying hex points, rocket fuel, and dice points by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels."
+                } else {
+                    let postCost = player.cb.totalxp.sub(tmp[this.layer].buyables[this.id].cost)
+                    return "which are multiplying hex points, rocket fuel, and dice points by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(player.cb.level.sub(layers.cb.xpToLevel(postCost))) + " Check Back Levels."
+                }
             },
             buy(mult) {
                 if (mult != true) {
@@ -2438,8 +2444,14 @@ addLayer("cb", {
                 return "Check Back IP Boost."
             },
             display() {
-                return "which are multiplying infinity points by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels worth of XP."
+                if (tmp[this.layer].buyables[this.id].cost.gte(player.cb.totalxp)) {
+                    return "which are multiplying infinity points by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels."
+                } else {
+                    let postCost = player.cb.totalxp.sub(tmp[this.layer].buyables[this.id].cost)
+                    return "which are multiplying infinity points by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(player.cb.level.sub(layers.cb.xpToLevel(postCost))) + " Check Back Levels."
+                }
             },
             buy(mult) {
                 if (mult != true) {
@@ -2474,8 +2486,14 @@ addLayer("cb", {
                 return "Check Back XP Boost Boost."
             },
             display() {
-                return "which are multiplying XPBoost by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels worth of XP."
+                if (tmp[this.layer].buyables[this.id].cost.gte(player.cb.totalxp)) {
+                    return "which are multiplying XPBoost by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels."
+                } else {
+                    let postCost = player.cb.totalxp.sub(tmp[this.layer].buyables[this.id].cost)
+                    return "which are multiplying XPBoost by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(player.cb.level.sub(layers.cb.xpToLevel(postCost))) + " Check Back Levels."
+                }
             },
             buy(mult) {
                 if (mult != true) {
@@ -2510,8 +2528,14 @@ addLayer("cb", {
                 return "Check Back Pet Point Boost."
             },
             display() {
-                return "which are multiplying pet points by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels worth of XP."
+                if (tmp[this.layer].buyables[this.id].cost.gte(player.cb.totalxp)) {
+                    return "which are multiplying pet points by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels."
+                } else {
+                    let postCost = player.cb.totalxp.sub(tmp[this.layer].buyables[this.id].cost)
+                    return "which are multiplying pet points by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(player.cb.level.sub(layers.cb.xpToLevel(postCost))) + " Check Back Levels."
+                }
             },
             buy(mult) {
                 if (mult != true) {
@@ -2546,8 +2570,14 @@ addLayer("cb", {
                 return "Check Back Pollinators Boost."
             },
             display() {
-                return "which are multiplying pollinators by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels worth of XP."
+                if (tmp[this.layer].buyables[this.id].cost.gte(player.cb.totalxp)) {
+                    return "which are multiplying pollinators by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels."
+                } else {
+                    let postCost = player.cb.totalxp.sub(tmp[this.layer].buyables[this.id].cost)
+                    return "which are multiplying pollinators by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(player.cb.level.sub(layers.cb.xpToLevel(postCost))) + " Check Back Levels."
+                }
             },
             buy(mult) {
                 if (mult != true) {
@@ -2582,8 +2612,14 @@ addLayer("cb", {
                 return "Check Back Pity Req. Reducer."
             },
             display() {
-                return "which are reducing the pity requirement by " + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
-                    Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels worth of XP."
+                if (tmp[this.layer].buyables[this.id].cost.gte(player.cb.totalxp)) {
+                    return "which are reducing the pity requirement by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(layers.cb.xpToLevel(tmp[this.layer].buyables[this.id].cost)) + " Check Back Levels."
+                } else {
+                    let postCost = player.cb.totalxp.sub(tmp[this.layer].buyables[this.id].cost)
+                    return "which are reducing the pity requirement by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                        Cost: " + formatWhole(player.cb.level.sub(layers.cb.xpToLevel(postCost))) + " Check Back Levels."
+                }
             },
             buy(mult) {
                 if (mult != true) {

--- a/js/checkback.js
+++ b/js/checkback.js
@@ -2335,25 +2335,12 @@ addLayer("cb", {
             player.cb.pityParaCurrent = player.cb.pityParaCurrent.add(10)
         } else if (rng < 0.05) {
             //the legendary stuff
-            let random = getRandomInt(3)
-            let gainedGems = getRandomInt(5) + 6
-            if (random == 0) {
-                player.cb.legendaryPetGems[0] = player.cb.legendaryPetGems[0].add(gainedGems);
-                if (!(player.tab == "cb" && player.subtabs["cb"]['stuff'] == 'Pets' && player.subtabs["pet"]['Content'] == 'Pet Shop')) {
-                    if (!(player.cb.petAutomationTimers[6].lt(1) && player.cb.petAutomationAllocation[6].gt(0)) && player.cb.alertToggle) callAlert("You gained " + formatWhole(gainedGems) + " Red Legendary Gems!", "resources/redLegendaryPetGem.png");
-                }
-            }
-            if (random == 1) {
-                player.cb.legendaryPetGems[1] = player.cb.legendaryPetGems[1].add(gainedGems);
-                if (!(player.tab == "cb" && player.subtabs["cb"]['stuff'] == 'Pets' && player.subtabs["pet"]['Content'] == 'Pet Shop')) {
-                    if (!(player.cb.petAutomationTimers[6].lt(1) && player.cb.petAutomationAllocation[6].gt(0)) && player.cb.alertToggle) callAlert("You gained " + formatWhole(gainedGems) + " Purple Legendary Gems!", "resources/purpleLegendaryPetGem.png");
-                }
-            }
-            if (random == 2) {
-                player.cb.legendaryPetGems[2] = player.cb.legendaryPetGems[2].add(gainedGems);
-                if (!(player.tab == "cb" && player.subtabs["cb"]['stuff'] == 'Pets' && player.subtabs["pet"]['Content'] == 'Pet Shop')) {
-                    if (!(player.cb.petAutomationTimers[6].lt(1) && player.cb.petAutomationAllocation[6].gt(0)) && player.cb.alertToggle) callAlert("You gained " + formatWhole(gainedGems) + " Green Legendary Gems!", "resources/greenLegendaryPetGem.png");
-                }
+            let gainedGems = getRandomInt(5) + 10
+            player.cb.legendaryPetGems[0] = player.cb.legendaryPetGems[0].add(gainedGems);
+            player.cb.legendaryPetGems[1] = player.cb.legendaryPetGems[1].add(gainedGems);
+            player.cb.legendaryPetGems[2] = player.cb.legendaryPetGems[2].add(gainedGems);
+            if (!(player.tab == "cb" && player.subtabs["cb"]['stuff'] == 'Pets' && player.subtabs["pet"]['Content'] == 'Pet Shop')) {
+                if (!(player.cb.petAutomationTimers[6].lt(1) && player.cb.petAutomationAllocation[6].gt(0)) && player.cb.alertToggle) callAlert("You gained " + formatWhole(gainedGems) + " of each Legendary Gem!", "resources/Pets/legendarybg.png");
             }
             player.cb.pityParaCurrent = player.cb.pityParaCurrent.add(10)
         }

--- a/js/mod.js
+++ b/js/mod.js
@@ -89,6 +89,19 @@ function updateStyles() {
 		}
 	}
 
+	// ===------   Universe Bar Horizontal Scrolling   ------=== //
+	let scrollContainer = document.querySelector('.uniHolder')
+	if (scrollContainer) {
+		scrollContainer.addEventListener("wheel", (event) => {
+    		event.preventDefault(); // Prevent default vertical scrolling
+
+    		// Adjust scrollLeft based on deltaY
+    		// event.deltaY is positive for scrolling down, negative for scrolling up
+    		// We map this to horizontal scrolling: positive deltaY moves right, negative moves left
+    		scrollContainer.scrollLeft += event.deltaY; 
+		});
+	}
+
 	// ===------   LAYER BACKGROUND   ------=== //
 	let layerBG = ""
 
@@ -1289,17 +1302,17 @@ function fixOldSave(oldVersion){
 		}
 		
 		
-		player.cs.scraps.point.amount = new Decimal(player.cs.resourceCoreScraps[0])
-		player.cs.scraps.factor.amount = new Decimal(player.cs.resourceCoreScraps[1])
-		player.cs.scraps.prestige.amount = new Decimal(player.cs.resourceCoreScraps[2])
-		player.cs.scraps.tree.amount = new Decimal(player.cs.resourceCoreScraps[3])
-		player.cs.scraps.grass.amount = new Decimal(player.cs.resourceCoreScraps[4])
-		player.cs.scraps.grasshopper.amount = new Decimal(player.cs.resourceCoreScraps[5])
-		player.cs.scraps.code.amount = new Decimal(player.cs.resourceCoreScraps[6])
-		player.cs.scraps.dice.amount = new Decimal(player.cs.resourceCoreScraps[7])
-		player.cs.scraps.rocket.amount = new Decimal(player.cs.resourceCoreScraps[8])
-		player.cs.scraps.antimatter.amount = new Decimal(player.cs.resourceCoreScraps[9])
-		player.cs.scraps.infinity.amount = new Decimal(player.cs.resourceCoreScraps[10])
-		player.cs.scraps.checkback.amount = new Decimal(player.cs.paragonScraps)
+		player.cs.scraps.point.amount = new Decimal(player.cs.resourceCoreScraps[0]).abs()
+		player.cs.scraps.factor.amount = new Decimal(player.cs.resourceCoreScraps[1]).abs()
+		player.cs.scraps.prestige.amount = new Decimal(player.cs.resourceCoreScraps[2]).abs()
+		player.cs.scraps.tree.amount = new Decimal(player.cs.resourceCoreScraps[3]).abs()
+		player.cs.scraps.grass.amount = new Decimal(player.cs.resourceCoreScraps[4]).abs()
+		player.cs.scraps.grasshopper.amount = new Decimal(player.cs.resourceCoreScraps[5]).abs()
+		player.cs.scraps.code.amount = new Decimal(player.cs.resourceCoreScraps[6]).abs()
+		player.cs.scraps.dice.amount = new Decimal(player.cs.resourceCoreScraps[7]).abs()
+		player.cs.scraps.rocket.amount = new Decimal(player.cs.resourceCoreScraps[8]).abs()
+		player.cs.scraps.antimatter.amount = new Decimal(player.cs.resourceCoreScraps[9]).abs()
+		player.cs.scraps.infinity.amount = new Decimal(player.cs.resourceCoreScraps[10]).abs()
+		player.cs.scraps.checkback.amount = new Decimal(player.cs.paragonScraps).abs()
 	}
 }

--- a/js/mod.js
+++ b/js/mod.js
@@ -609,6 +609,25 @@ let credits = `<h1>Credits:</h1><br>
 		`
 
 let changelog = `<h1>Changelog:</h1><br>
+	<h3>v1.8.2 - Hex Hotfix 2</h3><br>
+		Qol:<br>
+		- Changed the Uni-bar to scroll instead of using pages.<br>
+		- Removed eclipse cooldown, cause why would you want that.<br>
+		- Added legendary pet summon pity.<br><br>
+		Balancing:<br>
+		- Lowered realm essence upgrade cost scaling.<br>
+		- Made jinx automation be unlocked earlier into hex.<br>
+		- Slightly buffed unlockable singularity effect.<br>
+		- Improved legendary pet summon odds.<br>
+		- Improved legendary gem gain from RNG rolls.<br>
+		- Improved pet point gain from summoning altar.<br><br>
+		Bugfixes:<br>
+		- Added more crash prevention.<br>
+		- Fixed break infinity not requiring an OTF slot after unlocking singularity.<br>
+		- Fixed checkback buyable cost formatting.<br><br>
+		Typos:<br>
+		- Fixed fear being called anger.<br>
+		- Fixed some hex softcaps being called softlocks.<br><br>
 	<h3>v1.8.1 - Hex Hotfix 1</h3><br>
 		Bugfixes:<br>
 		- Boons now trigger a hold tick on click<br>

--- a/js/mod.js
+++ b/js/mod.js
@@ -93,13 +93,8 @@ function updateStyles() {
 	let scrollContainer = document.querySelector('.uniHolder')
 	if (scrollContainer) {
 		scrollContainer.addEventListener("wheel", (event) => {
-    		event.preventDefault(); // Prevent default vertical scrolling
-
-    		// Adjust scrollLeft based on deltaY
-    		// event.deltaY is positive for scrolling down, negative for scrolling up
-    		// We map this to horizontal scrolling: positive deltaY moves right, negative moves left
     		scrollContainer.scrollLeft += event.deltaY; 
-		});
+		}, {passive: true});
 	}
 
 	// ===------   LAYER BACKGROUND   ------=== //

--- a/js/mod.js
+++ b/js/mod.js
@@ -601,12 +601,12 @@ let credits = `<h1>Credits:</h1><br>
 		`
 
 let changelog = `<h1>Changelog:</h1><br>
-	<h4>v1.8.1 - Hex Hotfix 1</h3><br>
+	<h3>v1.8.1 - Hex Hotfix 1</h3><br>
 		Bugfixes:<br>
 		- Boons now trigger a hold tick on click<br>
 		- Fixed pet points and XPBoost being formatted incorrectly<br>
 		- Fixed edge-cases on save transfers<br><br>
-	<h3>v1.8 - The Hexing Revamp</h3><br>
+	<h2>v1.8 - The Hexing Revamp</h2><br>
 		Content:<br>
 			- Added Universe α: Hex.<br>
 			- Revamped the UI.<br>

--- a/js/portal.js
+++ b/js/portal.js
@@ -302,7 +302,7 @@ addLayer("po", {
             display() {
                 return player.po.breakInfinity ? "<h1>Get past limits.<br>On" : "<h1>Get past limits.<br>Off<br><h2>Req: Tav Defeated<br>Can't activate in Tav's domain";
             },
-            canClick() { return (player.po.featureSlots.gte(1) && player.in.unlockedBreak && !inChallenge("tad", 11)) || hasMilestone("s", 11)},
+            canClick() { return player.po.featureSlots.gte(1) && (player.in.unlockedBreak || hasMilestone("s", 11)) && !inChallenge("tad", 11)},
             unlocked() { return player.in.unlockedBreak },
             onClick() {
                 player.po.breakInfinity = true


### PR DESCRIPTION
<h3>v1.8.2 - Hex Hotfix 2</h3>
		Qol:<br>
		- Changed the Uni-bar to scroll instead of using pages.<br>
		- Removed eclipse cooldown, cause why would you want that.<br>
		- Added legendary pet summon pity.<br><br>
		Balancing:<br>
		- Lowered realm essence upgrade cost scaling.<br>
		- Made jinx automation be unlocked earlier into hex.<br>
		- Slightly buffed unlockable singularity effect.<br>
		- Improved legendary pet summon odds.<br>
		- Improved legendary gem gain from RNG rolls.<br>
		- Improved pet point gain from summoning altar.<br><br>
		Bugfixes:<br>
		- Added more crash prevention.<br>
		- Fixed break infinity not requiring an OTF slot after unlocking singularity.<br>
		- Fixed checkback buyable cost formatting.<br><br>
		Typos:<br>
		- Fixed fear being called anger.<br>
		- Fixed some hex softcaps being called softlocks.