### PR TITLE
Hex Hotfix 3

### DIFF
--- a/css/system-style.css
+++ b/css/system-style.css
@@ -200,7 +200,7 @@
 		width: calc(100% - 6px);
 	}
 	.uniButton {
-		width: 10%;
+		width: 12.5%;
 	}
 	.titleHolder {
 		width: 295px;

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
 		<div v-if="false" id="loadingSection" class="fullWidth">
 			<h1>Loading... (If this takes too long it means there was a serious error!)←</h1>
 		</div>
-		<div class="vl" v-if="player.navTab !== 'none' && tmp.other.splitScreen && player.tab!='none' && !(tmp.gameEnded && !player.keepGoing)"></div>
+		<div class="vl" v-if="tmp.other.splitScreen && player.tab!='none' && !(tmp.gameEnded && !player.keepGoing)"></div>
 		<div v-if="(tmp.gameEnded && !player.keepGoing)" class="fullWidth">
 			<br>
 			<h2>{{modInfo.name}} {{VERSION.withoutName}}</h2><br><br>
@@ -126,14 +126,12 @@
 			<br><br>
 		</div>
 
-		<div id="treeOverlay" v-if="!(tmp.gameEnded && !player.keepGoing) && (player.tab === 'none' || tmp.other.splitScreen || !readData(layoutInfo.showTree))" class="treeOverlay" onscroll="resizeCanvas()"
+		<div id="treeOverlay" v-if="!(tmp.gameEnded && !player.keepGoing) && (player.tab === 'none' || !readData(layoutInfo.showTree))" class="treeOverlay" onscroll="resizeCanvas()"
 			v-bind:class="{
-			fullWidth: (player.tab == 'none' || player.navTab == 'none'),
-			col: (player.tab !== 'none' && player.navTab !== 'none'),
-			left: (player.tab !== 'none' && player.navTab !== 'none')}"
+			fullWidth: (player.tab == 'none'),
+			col: (player.tab !== 'none'),
+			left: (player.tab !== 'none')}"
 			 :style="{'margin-top': !readData(layoutInfo.showTree) && player.tab == 'info-tab' ? '50px' : ''}">
-			<button
-			v-if="((player.navTab == 'none' && (tmp[player.tab].row == 'side' || tmp[player.tab].row == 'otherside' || player[player.tab].prevTab)) || player[player.navTab]?.prevTab)"				class="other-back overlayThing" onclick="goBack(player.navTab == 'none' ? player.tab : player.navTab)">←</button>
 			<overlay-head v-if="!(tmp.gameEnded && !player.keepGoing)"></overlay-head>
 			<div class="sideLayers">
 				<div v-for="(node, index) in OTHER_LAYERS['side']">
@@ -142,13 +140,13 @@
 			</div>
 		</div>
 
-		<div v-if="!(tmp.gameEnded && !player.keepGoing) && (player.tab === 'none' || tmp.other.splitScreen)" id="treeTab"  onscroll="resizeCanvas()"
-			v-bind:class="{ fullWidth: (player.tab == 'none' || player.navTab == 'none'), col: (player.tab !== 'none' && player.navTab !== 'none'), left: (player.tab !== 'none' && player.navTab !== 'none')}">
+		<div v-if="!(tmp.gameEnded && !player.keepGoing) && (player.tab === 'none')" id="treeTab"  onscroll="resizeCanvas()"
+			v-bind:class="{ fullWidth: (player.tab == 'none'), col: (player.tab !== 'none'), left: (player.tab !== 'none')}">
 			<br><br><br><br>
 			<overlay-head id="fakeHead" style="visibility: hidden;">
 			</overlay-head>
-			<layer-tab :layer="player.navTab == 'none' ? player.tab : player.navTab" :key="'left'"></layer-tab>
-			<bg :layer="player.navTab == 'none' ? player.tab : player.navTab" ></bg>
+			<layer-tab :layer="player.tab" :key="'left'"></layer-tab>
+			<bg :layer="player.tab"></bg>
 		</div>
 
 		<!-- Popups -->
@@ -167,7 +165,7 @@
 				</div>
 		</div>
 
-		<div id="layerHolder" v-if="player.navTab !== 'none' && player.tab !== 'none' && !(tmp.gameEnded && !player.keepGoing)" onscroll="resizeCanvas()" v-bind:class="{fullWidth: player.navTab == 'none' || !tmp.other.splitScreen || !readData(layoutInfo.showTree), fast: true, tab: true}">
+		<div id="layerHolder" v-if="player.tab !== 'none' && !(tmp.gameEnded && !player.keepGoing)" onscroll="resizeCanvas()" v-bind:class="{fullWidth: true, fast: true, tab: true}">
 			<div v-for="layer in LAYERS">
 				<div v-if="player.tab==layer">
 					<layer-tab :layer="layer" :back="'none'" :spacing="'50px'" :key="'left'"></layer-tab>

--- a/js/Cantepocalypse/cantepocalypse.js
+++ b/js/Cantepocalypse/cantepocalypse.js
@@ -25,8 +25,7 @@ addLayer("cp", {
         replicantiSoftcap2Start: new Decimal(1e10),
     }},
     automate() {
-        if (hasMilestone("s", 17) && !inChallenge("fu", 11))
-        {
+        if (hasMilestone("s", 17) && !inChallenge("fu", 11)) {
             buyUpgrade("cp", 11)
             buyUpgrade("cp", 12)
             buyUpgrade("cp", 13)
@@ -35,6 +34,7 @@ addLayer("cp", {
             buyUpgrade("cp", 16)
             buyUpgrade("cp", 17)
             buyUpgrade("cp", 18)
+            buyUpgrade("cp", 19)
         }
     },
     nodeStyle: {background: "linear-gradient(45deg, #064461 0%, #4a7d94 100%)", backgroundOrigin: "border-box", borderColor: "#013851"},

--- a/js/Hex/blessings.js
+++ b/js/Hex/blessings.js
@@ -205,6 +205,7 @@ addLayer("hbl", {
             },
             canClick: true,
             unlocked: true,
+            tooltip: "Works outside of hex.",
             onClick() {this.onHold()},
             onHold() {
                 let amt = player.hbl.boosterReq[2].mul(player.hbl.boosterDeposit).min(player.hbl.boosterReq[2].sub(player.hbl.boosterXP[2]))

--- a/js/Hex/curses.js
+++ b/js/Hex/curses.js
@@ -22,7 +22,7 @@ addLayer("hcu", {
     update(delta) {
         player.hcu.cursesGain = new Decimal(0)
         if (hasUpgrade("ta", 16)) player.hcu.cursesGain = player.hbl.blessings.add(1).log(6)
-        if (hasUpgrade("ta", 16) && inChallenge("hrm", 13)) player.hcu.cursesGain = Decimal.pow(player.hve.vexTotal.mul(0.2).add(1.8), player.hbl.blessings.add(1).log(6)).sub(1)
+        if (hasUpgrade("ta", 16) && inChallenge("hrm", 13)) player.hcu.cursesGain = Decimal.pow(player.hve.vexTotal.mul(0.2).add(1.8), player.hbl.blessings.add(1).log(6)).sub(1).min(1e30)
         if (hasUpgrade("ta", 16) && hasMilestone("hre", 9)) player.hcu.cursesGain = player.hcu.cursesGain.add(0.6)
         player.hcu.cursesGain = player.hcu.cursesGain.mul(buyableEffect("hcu", 101))
         player.hcu.cursesGain = player.hcu.cursesGain.mul(buyableEffect("hcu", 103))
@@ -143,7 +143,7 @@ addLayer("hcu", {
             },
             effect(x) {
                 let amt = getBuyableAmount(this.layer, this.id).add(tmp[this.layer].buyables[this.id].extraAmount)
-                if (amt.gte(80)) Decimal.mul(0.01, amt).add(7.2)
+                if (amt.gte(100)) return Decimal.mul(0.01, amt).add(9)
                 return Decimal.mul(0.1, amt)
             },
             unlocked() { return true },
@@ -157,7 +157,7 @@ addLayer("hcu", {
             title() { return "Β-Jinx" },
             display() {
                 let amt = getBuyableAmount(this.layer, this.id).add(tmp[this.layer].buyables[this.id].extraAmount)
-                if (amt.gte(80)) return "Increase Α-Jinx's effect by +0.01x<br><small style='color:red'>[SOFTCAPPED]</small>"
+                if (amt.gte(100)) return "Increase Α-Jinx's effect by +0.01x<br><small style='color:red'>[SOFTCAPPED]</small>"
                 return "Increase Α-Jinx's effect by +0.1x"
             },
             total() { return "(Total: +" + format(tmp[this.layer].buyables[this.id].effect) + "x)" },

--- a/js/Hex/curses.js
+++ b/js/Hex/curses.js
@@ -439,6 +439,7 @@ addLayer("hcu", {
             purchaseLimit() { return new Decimal(30).add(player.hcu.jinxAddCap).div(2).floor() },
             currency() { return player.hcu.curses},
             pay(amt) { player.hcu.curses = this.currency().sub(amt).max(0) },
+            tooltip: "Works outside of hex.",
             extraAmount() {
                 let amt = new Decimal(0)
                 if (hasUpgrade("hve", 51)) amt = amt.add(1)

--- a/js/Hex/hex.js
+++ b/js/Hex/hex.js
@@ -73,6 +73,7 @@ addLayer("h", {
         if (hasUpgrade("hpw", 141)) player.h.prePowerMult = player.h.prePowerMult.mul(upgradeEffect("hpw", 141))
         player.h.prePowerMult = player.h.prePowerMult.mul(levelableEffect("pu", 107)[1])
         player.h.prePowerMult = player.h.prePowerMult.mul(levelableEffect("pet", 1106)[0])
+        player.h.prePowerMult = player.h.prePowerMult.div(player.hrm.challengeSoftcap)
     },
     hexReq(value, base, scale, div = new Decimal(1), add = new Decimal(1)) {
         return value.add(add).pow(scale).mul(base).div(div).ceil()

--- a/js/Hex/power.js
+++ b/js/Hex/power.js
@@ -649,7 +649,7 @@ addLayer("hpw", {
         },
         1011: {
             title: "Might A:1",
-            unlocked() {return challengeCompletions("hrm", 11) >= 1},
+            unlocked() {return challengeCompletions("hrm", 11) >= 1 && hasUpgrade("bi", 27)},
             description: "Boost check back xp based on power.",
             branches: [1001],
             cost() {return new Decimal(6)},
@@ -665,7 +665,7 @@ addLayer("hpw", {
         },
         1012: {
             title: "Might A:2",
-            unlocked() {return challengeCompletions("hrm", 11) >= 2},
+            unlocked() {return challengeCompletions("hrm", 11) >= 2 && hasUpgrade("bi", 27)},
             description: "Raise rank, tier, tetr, and pent effects by ^1.18.",
             branches: [1001],
             cost() {return new Decimal(36)},
@@ -677,7 +677,7 @@ addLayer("hpw", {
         },
         1013: {
             title: "Might A:3",
-            unlocked() {return challengeCompletions("hrm", 11) >= 3},
+            unlocked() {return challengeCompletions("hrm", 11) >= 3 && hasUpgrade("bi", 27)},
             description: "Multiply factor base by x120.",
             branches: [1001],
             cost() {return new Decimal(216)},
@@ -689,7 +689,7 @@ addLayer("hpw", {
         },
         1021: {
             title: "Might B:1",
-            unlocked() {return challengeCompletions("hrm", 12) >= 1},
+            unlocked() {return challengeCompletions("hrm", 12) >= 1 && hasUpgrade("bi", 27)},
             description: "Boost crystals and steel based on power.",
             branches: [1002],
             cost() {return new Decimal(36)},
@@ -705,7 +705,7 @@ addLayer("hpw", {
         },
         1022: {
             title: "Might B:2",
-            unlocked() {return challengeCompletions("hrm", 12) >= 2},
+            unlocked() {return challengeCompletions("hrm", 12) >= 2 && hasUpgrade("bi", 27)},
             description: "Raise prestige points gain by ^1.36.",
             branches: [1002],
             cost() {return new Decimal(216)},
@@ -717,7 +717,7 @@ addLayer("hpw", {
         },
         1023: {
             title: "Might B:3",
-            unlocked() {return challengeCompletions("hrm", 12) >= 3},
+            unlocked() {return challengeCompletions("hrm", 12) >= 3 && hasUpgrade("bi", 27)},
             description: "Raise tree gain by ^1.24.",
             branches: [1002],
             cost() {return new Decimal(1296)},
@@ -729,7 +729,7 @@ addLayer("hpw", {
         },
         1031: {
             title: "Might C:1",
-            unlocked() {return challengeCompletions("hrm", 13) >= 1},
+            unlocked() {return challengeCompletions("hrm", 13) >= 1 && hasUpgrade("bi", 27)},
             description: "Improve Might 1:2's effect.",
             branches: [1003],
             cost() {return new Decimal(216)},
@@ -741,7 +741,7 @@ addLayer("hpw", {
         },
         1032: {
             title: "Might C:2",
-            unlocked() {return challengeCompletions("hrm", 13) >= 2},
+            unlocked() {return challengeCompletions("hrm", 13) >= 2 && hasUpgrade("bi", 27)},
             description: "Raise grass gain by ^1.18.",
             branches: [1003],
             cost() {return new Decimal(1296)},
@@ -753,7 +753,7 @@ addLayer("hpw", {
         },
         1033: {
             title: "Might C:3",
-            unlocked() {return challengeCompletions("hrm", 13) >= 3},
+            unlocked() {return challengeCompletions("hrm", 13) >= 3 && hasUpgrade("bi", 27)},
             description: "Raise golden grass gain by ^1.06.",
             branches: [1003],
             cost() {return new Decimal(7776)},
@@ -765,7 +765,7 @@ addLayer("hpw", {
         },
         1041: {
             title: "Might D:1",
-            unlocked() {return challengeCompletions("hrm", 14) >= 1},
+            unlocked() {return challengeCompletions("hrm", 14) >= 1 && hasUpgrade("bi", 27)},
             description: "Boost infinity dimensions based on power.",
             branches: [1004],
             cost() {return new Decimal(46656)},
@@ -781,7 +781,7 @@ addLayer("hpw", {
         },
         1042: {
             title: "Might D:2",
-            unlocked() {return challengeCompletions("hrm", 14) >= 2},
+            unlocked() {return challengeCompletions("hrm", 14) >= 2 && hasUpgrade("bi", 27)},
             description: "Raise grasshopper gain by ^1.1.",
             branches: [1004],
             cost() {return new Decimal(279936)},
@@ -793,7 +793,7 @@ addLayer("hpw", {
         },
         1043: {
             title: "Might D:3",
-            unlocked() {return challengeCompletions("hrm", 14) >= 3},
+            unlocked() {return challengeCompletions("hrm", 14) >= 3 && hasUpgrade("bi", 27)},
             description: "Raise mod gain by ^1.1.",
             branches: [1004],
             cost() {return new Decimal(1679616)},
@@ -805,7 +805,7 @@ addLayer("hpw", {
         },
         1051: {
             title: "Might E:1",
-            unlocked() {return challengeCompletions("hrm", 15) >= 1},
+            unlocked() {return challengeCompletions("hrm", 15) >= 1 && hasUpgrade("bi", 27)},
             description: "Boost mastery point effects based on power.",
             branches: [1005],
             cost() {return new Decimal(1679616)},
@@ -821,7 +821,7 @@ addLayer("hpw", {
         },
         1052: {
             title: "Might E:2",
-            unlocked() {return challengeCompletions("hrm", 15) >= 2},
+            unlocked() {return challengeCompletions("hrm", 15) >= 2 && hasUpgrade("bi", 27)},
             description: "Raise AD and antimatter by ^1.05.",
             branches: [1005],
             cost() {return new Decimal(10077696)},
@@ -833,7 +833,7 @@ addLayer("hpw", {
         },
         1053: {
             title: "Might E:3",
-            unlocked() {return challengeCompletions("hrm", 15) >= 3},
+            unlocked() {return challengeCompletions("hrm", 15) >= 3 && hasUpgrade("bi", 27)},
             description: "Multiply NIP by x100.",
             branches: [1005],
             cost() {return new Decimal(60466176)},
@@ -845,7 +845,7 @@ addLayer("hpw", {
         },
         1061: {
             title: "Might F:1",
-            unlocked() {return challengeCompletions("hrm", 16) >= 1},
+            unlocked() {return challengeCompletions("hrm", 16) >= 1 && hasUpgrade("bi", 27)},
             description: "Boost infinity points based on power.",
             branches: [1006],
             cost() {return new Decimal(362797056)},
@@ -861,7 +861,7 @@ addLayer("hpw", {
         },
         1062: {
             title: "Might F:2",
-            unlocked() {return challengeCompletions("hrm", 16) >= 2},
+            unlocked() {return challengeCompletions("hrm", 16) >= 2 && hasUpgrade("bi", 27)},
             description: "Gain 10% infinities per second.",
             branches: [1006],
             cost() {return new Decimal(2176782336)},
@@ -873,7 +873,7 @@ addLayer("hpw", {
         },
         1063: {
             title: "Might F:3",
-            unlocked() {return challengeCompletions("hrm", 16) >= 3},
+            unlocked() {return challengeCompletions("hrm", 16) >= 3 && hasUpgrade("bi", 27)},
             description: "Triple replicanti mult.",
             branches: [1006],
             cost() {return new Decimal(13060694016)},
@@ -1075,10 +1075,16 @@ addLayer("hpw", {
                     ["blank", "5px"],
                     ["clickable", 2],
                     ["row", [
-                        ["blank", ["140px", "140px"]],
+                        ["blank", ["280px", "140px"]],
                         ["upgrade", 1],
                         ["upgrade", 2],
                         ["style-row", [["upgrade", 1011]], {width: "140px", height: "140px"}],
+                        ["style-column", [
+                            ["raw-html", "Realm mights work outside of hex.", {color: "rgba(0,0,0,0.6)", userSelect: "none", fontSize: "14px", fontFamily: "monospace"}],
+                        ], () => {
+                            if (hasUpgrade("bi", 27)) return {width: "110px", height: "110px", backgroundColor: "#933", border: "5px solid rgba(0,0,0,0.5)", margin: "10px", borderRadius: "25px"}
+                            return {width: "140px", height: "140px", visibility: "hidden"}
+                        }],
                     ]],
                     ["row", [
                         ["blank", ["140px", "140px"]],
@@ -1187,7 +1193,7 @@ addLayer("hpw", {
                         ["style-column", [
                             ["raw-html", "Kept on singularity<br>First purchase keeps the respective realm challenge on singularity", {color: "rgba(0,0,0,0.6)", userSelect: "none", fontSize: "14px", fontFamily: "monospace"}],
                         ], () => {
-                            if (challengeCompletions("hrm", 12) >= 3) return {width: "180px", height: "110px", backgroundColor: "#933", border: "5px solid rgba(0,0,0,0.5)", margin: "10px", borderRadius: "25px"}
+                            if (hasUpgrade("bi", 27)) return {width: "180px", height: "110px", backgroundColor: "#933", border: "5px solid rgba(0,0,0,0.5)", margin: "10px", borderRadius: "25px"}
                             return {width: "210px", height: "140px", visibility: "hidden"}
                         }],
                     ]],

--- a/js/Hex/power.js
+++ b/js/Hex/power.js
@@ -651,6 +651,7 @@ addLayer("hpw", {
             title: "Might A:1",
             unlocked() {return challengeCompletions("hrm", 11) >= 1 && hasUpgrade("bi", 27)},
             description: "Boost check back xp based on power.",
+            tooltip: "Realm mights work outside of hex.",
             branches: [1001],
             cost() {return new Decimal(6)},
             canAfford() { return hasUpgrade("hpw", 1001)},
@@ -1075,16 +1076,10 @@ addLayer("hpw", {
                     ["blank", "5px"],
                     ["clickable", 2],
                     ["row", [
-                        ["blank", ["280px", "140px"]],
+                        ["blank", ["140px", "140px"]],
                         ["upgrade", 1],
                         ["upgrade", 2],
                         ["style-row", [["upgrade", 1011]], {width: "140px", height: "140px"}],
-                        ["style-column", [
-                            ["raw-html", "Realm mights work outside of hex.", {color: "rgba(0,0,0,0.6)", userSelect: "none", fontSize: "14px", fontFamily: "monospace"}],
-                        ], () => {
-                            if (hasUpgrade("bi", 27)) return {width: "110px", height: "110px", backgroundColor: "#933", border: "5px solid rgba(0,0,0,0.5)", margin: "10px", borderRadius: "25px"}
-                            return {width: "140px", height: "140px", visibility: "hidden"}
-                        }],
                     ]],
                     ["row", [
                         ["blank", ["140px", "140px"]],

--- a/js/Hex/realms.js
+++ b/js/Hex/realms.js
@@ -10,6 +10,7 @@ addLayer("hrm", {
         realmEffect: new Decimal(1),
         blessLimit: new Decimal(0),
         dreamTimer: new Decimal(60),
+        challengeSoftcap: new Decimal(1),
 
         realmEssence: new Decimal(0),
         totalRealmEssence: new Decimal(0),
@@ -43,6 +44,13 @@ addLayer("hrm", {
             player.hrm.dreamTimer = player.hrm.dreamTimer.sub(delta)
             if (player.hrm.dreamTimer.lte(0)) {
                 completeChallenge("hrm", 15)
+            }
+        }
+
+        player.hrm.challengeSoftcap = new Decimal(1)
+        if (player.hrm.activeChallenge) {
+            if (player.hrm.challenges[player.hrm.activeChallenge] > 10) {
+                player.hrm.challengeSoftcap = Decimal.pow(6, player.hrm.challenges[player.hrm.activeChallenge] - 9)
             }
         }
     },
@@ -454,6 +462,10 @@ addLayer("hrm", {
                         if (!hasUpgrade("bi", 27)) {look.opacity = "0.3";look.userSelect = "none"}
                         return look
                     }],
+                    ["blank", "25px"],
+                    ["style-row", [
+                        ["raw-html", () => {return ">9 CHALLENGE CLEAR SOFTCAP:<br>/" + formatWhole(player.hrm.challengeSoftcap) + " Pre-Power Resources"}, {color: "white", fontSize: "20px", fontFamily: "monospace"}],
+                    ], () => {return player.hrm.challengeSoftcap.gt(1) ? {width: "600px", height: "50px", background: "linear-gradient(90deg, #530000, #533a00, #515300, #0e5300, #00531d, #005349, #004677, #003153, #230053, #4f0053)", border: "3px solid white", borderRadius: "20px"} : {display: "none !important"}}],
                 ],
             },
             "Essence": {
@@ -486,7 +498,7 @@ addLayer("hrm", {
                     ], {width: "760px", height: "180px", background: "linear-gradient(90deg, #2f0000, #2f2100, #2e2f00, #082f00, #002f10, #002f2a, #004677, #001c2f, #14002f, #2d002f)", border: "3px solid white", borderRadius: "20px"}],
                     ["style-column", [
                         ["raw-html", "Realm essence gain is based on realm challenge clears,<br>and is gained on singularity reset.", {color: "white", fontSize: "18px", fontFamily: "monospace"}],
-                    ], {width: "600px", height: "50px", background: "linear-gradient(90deg, #530000, #533a00, #515300, #0e5300, #00531d, #005349, #004677, #003153, #230053, #4f0053)", borderBottom: "3px solid white", borderLeft: "3px solid white", borderRight: "3px solid white", borderRadius: "0 0 20px 20px"}]
+                    ], {width: "600px", height: "50px", background: "linear-gradient(90deg, #530000, #533a00, #515300, #0e5300, #00531d, #005349, #004677, #003153, #230053, #4f0053)", borderBottom: "3px solid white", borderLeft: "3px solid white", borderRight: "3px solid white", borderRadius: "0 0 20px 20px"}],
                 ],
             },
         },

--- a/js/Hex/realms.js
+++ b/js/Hex/realms.js
@@ -49,8 +49,8 @@ addLayer("hrm", {
 
         player.hrm.challengeSoftcap = new Decimal(1)
         if (player.hrm.activeChallenge) {
-            if (player.hrm.challenges[player.hrm.activeChallenge] > 10) {
-                player.hrm.challengeSoftcap = Decimal.pow(6, player.hrm.challenges[player.hrm.activeChallenge] - 9)
+            if (player.hrm.challenges[player.hrm.activeChallenge] > 5) {
+                player.hrm.challengeSoftcap = Decimal.pow(3, player.hrm.challenges[player.hrm.activeChallenge] - 5)
             }
         }
     },
@@ -464,7 +464,7 @@ addLayer("hrm", {
                     }],
                     ["blank", "25px"],
                     ["style-row", [
-                        ["raw-html", () => {return ">9 CHALLENGE CLEAR SOFTCAP:<br>/" + formatWhole(player.hrm.challengeSoftcap) + " Pre-Power Resources"}, {color: "white", fontSize: "20px", fontFamily: "monospace"}],
+                        ["raw-html", () => {return "<span style='color:#f44'>CHALLENGE SOFTCAP</span><br>/" + formatWhole(player.hrm.challengeSoftcap) + " Pre-Power Resources"}, {color: "white", fontSize: "20px", fontFamily: "monospace"}],
                     ], () => {return player.hrm.challengeSoftcap.gt(1) ? {width: "600px", height: "50px", background: "linear-gradient(90deg, #530000, #533a00, #515300, #0e5300, #00531d, #005349, #004677, #003153, #230053, #4f0053)", border: "3px solid white", borderRadius: "20px"} : {display: "none !important"}}],
                 ],
             },

--- a/js/Singularity/matos.js
+++ b/js/Singularity/matos.js
@@ -4224,12 +4224,30 @@
                             ["blank", ["50px", "50px"]],
                             ["clickable", 104],
                             ["style-row", [
-                                ["raw-html", () => {return player.ma.airCelestialite ? "≋" : ""}, {color: "#ccc", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
-                                ["raw-html", () => {return player.ma.shieldCelestialite ? "⛊" : ""}, {color: "#5c5c5c", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
-                                ["raw-html", () => {return player.ma.regenCelestialite ? "♡" : ""}, {color: "#bb8888", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
-                                ["raw-html", () => {return player.ma.stealthyCelestialite ? "☉" : ""}, {color: "#78866b", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
-                                ["raw-html", () => {return player.ma.cursedCelestialite ? "✶" : ""}, {color: "#8b0e7a", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
-                                ["raw-html", () => {return player.ma.explosiveCelestialite ? "✺" : ""}, {color: "#ee8700", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
+                                ["tooltip-row", [
+                                    ["raw-html", () => {return player.ma.airCelestialite ? "≋" : ""}, {color: "#ccc", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
+                                    ["raw-html", () => {return player.ma.airCelestialite ? "<div class='bottomTooltip' style='margin-top:0px'>Air<hr>Can't be targeted by<br>melee attacks.</div>" : ""}],
+                                ]],
+                                ["tooltip-row", [
+                                    ["raw-html", () => {return player.ma.shieldCelestialite ? "⛊" : ""}, {color: "#5c5c5c", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
+                                    ["raw-html", () => {return player.ma.shieldCelestialite ? "<div class='bottomTooltip' style='margin-top:0px'>Shield<hr>Starts with a shield<br>that is immune to<br>ranged and magic<br>attacks.</div>" : ""}],
+                                ]],
+                                ["tooltip-row", [
+                                    ["raw-html", () => {return player.ma.regenCelestialite ? "♡" : ""}, {color: "#bb8888", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
+                                    ["raw-html", () => {return player.ma.regenCelestialite ? "<div class='bottomTooltip' style='margin-top:0px'>Regen<hr>Regenerates health<br>over time.</div>" : ""}],
+                                ]],
+                                ["tooltip-row", [
+                                    ["raw-html", () => {return player.ma.stealthyCelestialite ? "☉" : ""}, {color: "#78866b", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
+                                    ["raw-html", () => {return player.ma.stealthyCelestialite ? "<div class='bottomTooltip' style='margin-top:0px'>Stealthy<hr>Can't be targeted by<br>melee and magic<br>attacks.</div>" : ""}],
+                                ]],
+                                ["tooltip-row", [
+                                    ["raw-html", () => {return player.ma.cursedCelestialite ? "✶" : ""}, {color: "#8b0e7a", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
+                                    ["raw-html", () => {return player.ma.cursedCelestialite ? "<div class='bottomTooltip' style='margin-top:0px'>Cursed<hr>Has a 30% chance to<br>reflect damage back<br>towards you.</div>" : ""}],
+                                ]],
+                                ["tooltip-row", [
+                                    ["raw-html", () => {return player.ma.explosiveCelestialite ? "✺" : ""}, {color: "#ee8700", fontSize: "50px", fontFamily: "monospace", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black"}],
+                                    ["raw-html", () => {return player.ma.explosiveCelestialite ? "<div class='bottomTooltip' style='margin-top:0px'>Explosive<hr>Explodes upon death,<br>dealing damage to<br>all team members.</div>" : ""}],
+                                ]],
                             ], {width: "50px", height: "50px"}],
                         ]],
                     ]],

--- a/js/Singularity/matos.js
+++ b/js/Singularity/matos.js
@@ -4541,7 +4541,7 @@ function flashScreen(message, duration) {
     overlay.style.top = "0";
     overlay.style.width = "100vw";
     overlay.style.height = "100vh";
-    overlay.style.background = "#fff";
+    overlay.style.background = "black";
     overlay.style.zIndex = "999999";
     overlay.style.display = "flex";
     overlay.style.alignItems = "center";
@@ -4552,7 +4552,7 @@ function flashScreen(message, duration) {
     // Create text
     const text = document.createElement("div");
     text.innerText = message;
-    text.style.color = "#000";
+    text.style.color = "white";
     text.style.fontSize = "3vw";
     text.style.fontWeight = "bold";
     text.style.textAlign = "center";

--- a/js/Singularity/starmetalAlloy.js
+++ b/js/Singularity/starmetalAlloy.js
@@ -36,6 +36,7 @@
         // Set Autocrunch Values
         if (player.sma.input.gte(1) && !player.sma.type) player.sma.amount = player.sma.input
         if (player.sma.input.lt(1) && !player.sma.type) player.sma.amount = new Decimal(1)
+        if (player.sma.input.gt(0) && player.sma.type) player.sma.amount = player.sma.input
 
         if (player.s.singularityPointsToGet.gte(player.sma.amount) && player.sma.toggle && !player.sma.type) {
             clickClickable("co", 1000)

--- a/js/cantepocalypsePuzzle.js
+++ b/js/cantepocalypsePuzzle.js
@@ -96,7 +96,7 @@ addLayer("cap", {
             new Decimal(777).abs(),
             new Decimal(0.45).abs(),
             new Decimal(18).abs(),
-            new Decimal(15).abs(),
+            new Decimal(14).abs(),
             new Decimal(0)
         ]
 

--- a/js/components.js
+++ b/js/components.js
@@ -759,7 +759,7 @@ function loadVue() {
 			v-if="tmp[layer].clickables && tmp[layer].clickables[data]!== undefined && tmp[layer].clickables[data].unlocked"
 			v-bind:class="{ upg: true, tooltipBox: true, can: tmp[layer].clickables[data].canClick, locked: !tmp[layer].clickables[data].canClick}"
 			v-bind:style="[tmp[layer].clickables[data].canClick ? {'background-color': tmp[layer].color} : {}, tmp[layer].clickables[data].style]"
-			v-on:click="if(!interval) clickClickable(layer, data)" :id='"clickable-" + layer + "-" + data' @mousedown="start" @mouseleave="stop" @mouseup="stop" @touchstart="start;hover" @touchend="stop" @touchcancel="stop" @mouseenter="hover">
+			v-on:click="if(!interval) clickClickable(layer, data)" :id='"clickable-" + layer + "-" + data' @mousedown="start" @mouseleave="stop" @mouseup="stop" @touchstart="start" @touchend="stop" @touchcancel="stop" @touchmove="hover" @mouseenter="hover">
 			<span v-if= "tmp[layer].clickables[data].title" v-bind:style="{'transition-duration': '0s'}"><h2 v-html="tmp[layer].clickables[data].title" v-bind:style="{'transition-duration': '0s'}"></h2><br></span>
 			<span v-bind:style="{'white-space': 'pre-line','transition-duration': '0s'}" v-html="run(layers[layer].clickables[data].display, layers[layer].clickables[data])"></span>
 			<node-mark :layer='layer' :data='tmp[layer].clickables[data].marked'></node-mark>
@@ -777,7 +777,9 @@ function loadVue() {
 							run(c.onHold, c)
 						}
 						this.time = this.time+1
-					}).bind(this), 50)}
+					}).bind(this), 50)
+				}
+				this.hover()
 			},
 			stop() {
 				clearInterval(this.interval)
@@ -798,7 +800,7 @@ function loadVue() {
 			v-if="tmp[layer].clickables && tmp[layer].clickables[data]!== undefined && tmp[layer].clickables[data].unlocked"
 			v-bind:class="{ upg: true, tooltipBox: true, can: tmp[layer].clickables[data].canClick, locked: !tmp[layer].clickables[data].canClick}"
 			v-bind:style="[tmp[layer].clickables[data].canClick ? {'background-color': tmp[layer].color} : {}, tmp[layer].clickables[data].style]"
-			v-on:click="if(!interval) clickClickable(layer, data)" :id='"clickable-" + layer + "-" + data' @mousedown="start" @mouseleave="stop" @mouseup="stop" @touchstart="start;hover" @touchend="stop" @touchcancel="stop" @mouseenter="hover">
+			v-on:click="if(!interval) clickClickable(layer, data)" :id='"clickable-" + layer + "-" + data' @mousedown="start" @mouseleave="stop" @mouseup="stop" @touchstart="start" @touchend="stop" @touchcancel="stop" @touchmove="hover" @mouseenter="hover">
 			<span v-if= "tmp[layer].clickables[data].title" v-bind:style="{'transition-duration': '0s'}"><h2 v-html="tmp[layer].clickables[data].title" v-bind:style="{'transition-duration': '0s'}"></h2><br></span>
 			<span v-bind:style="{'white-space': 'pre-line','transition-duration': '0s'}" v-html="run(layers[layer].clickables[data].display, layers[layer].clickables[data])"></span>
 			<node-mark :layer='layer' :data='tmp[layer].clickables[data].marked'></node-mark>
@@ -816,7 +818,9 @@ function loadVue() {
 							run(c.onHold, c)
 						}
 						this.time = this.time+1
-					}).bind(this), 50)}
+					}).bind(this), 50)
+				}
+				this.hover()
 			},
 			stop() {
 				clearInterval(this.interval)
@@ -837,7 +841,7 @@ function loadVue() {
 			v-if="tmp[layer].clickables && tmp[layer].clickables[data]!== undefined && tmp[layer].clickables[data].unlocked"
 			v-bind:class="{ upg: true, tooltipBox: true, canHoverless: tmp[layer].clickables[data].canClick, locked: !tmp[layer].clickables[data].canClick}"
 			v-bind:style="[tmp[layer].clickables[data].canClick ? {'background-color': tmp[layer].color} : {}, tmp[layer].clickables[data].style]"
-			v-on:click="if(!interval) clickClickable(layer, data)" :id='"clickable-" + layer + "-" + data' @mousedown="start" @mouseleave="stop" @mouseup="stop" @touchstart="start;hover" @touchend="stop" @touchcancel="stop" @mouseenter="hover">
+			v-on:click="if(!interval) clickClickable(layer, data)" :id='"clickable-" + layer + "-" + data' @mousedown="start" @mouseleave="stop" @mouseup="stop" @touchstart="start" @touchend="stop" @touchcancel="stop" @touchmove="hover" @mouseenter="hover">
 			<span v-if= "tmp[layer].clickables[data].title" v-bind:style="{'transition-duration': '0s'}"><h2 v-html="tmp[layer].clickables[data].title" v-bind:style="{'transition-duration': '0s'}"></h2><br></span>
 			<span v-bind:style="{'white-space': 'pre-line','transition-duration': '0s'}" v-html="run(layers[layer].clickables[data].display, layers[layer].clickables[data])"></span>
 			<node-mark :layer='layer' :data='tmp[layer].clickables[data].marked'></node-mark>
@@ -855,7 +859,9 @@ function loadVue() {
 							run(c.onHold, c)
 						}
 						this.time = this.time+1
-					}).bind(this), 50)}
+					}).bind(this), 50)
+				}
+				this.hover()
 			},
 			stop() {
 				clearInterval(this.interval)

--- a/js/mod.js
+++ b/js/mod.js
@@ -609,6 +609,25 @@ let credits = `<h1>Credits:</h1><br>
 		`
 
 let changelog = `<h1>Changelog:</h1><br>
+	<h3>v1.8.2 - Hex Hotfix 2</h3><br>
+		Qol:<br>
+		- Changed the Uni-bar to scroll instead of using pages.<br>
+		- Removed eclipse cooldown, cause why would you want that.<br>
+		- Added legendary pet summon pity.<br><br>
+		Balancing:<br>
+		- Lowered realm essence upgrade cost scaling.<br>
+		- Made jinx automation be unlocked earlier into hex.<br>
+		- Slightly buffed unlockable singularity effect.<br>
+		- Improved legendary pet summon odds.<br>
+		- Improved legendary gem gain from RNG rolls.<br>
+		- Improved pet point gain from summoning altar.<br><br>
+		Bugfixes:<br>
+		- Added more crash prevention.<br>
+		- Fixed break infinity not requiring an OTF slot after unlocking singularity.<br>
+		- Fixed checkback buyable cost formatting.<br><br>
+		Typos:<br>
+		- Fixed fear being called anger.<br>
+		- Fixed some hex softcaps being called softlocks.<br><br>
 	<h3>v1.8.1 - Hex Hotfix 1</h3><br>
 		Bugfixes:<br>
 		- Boons now trigger a hold tick on click<br>

--- a/js/mod.js
+++ b/js/mod.js
@@ -609,7 +609,7 @@ let credits = `<h1>Credits:</h1><br>
 		`
 
 let changelog = `<h1>Changelog:</h1><br>
-	<h3>v1.8.3 - Hex Hotfix 3</h3>
+	<h3>v1.8.3 - Hex Hotfix 3</h3><br>
 		Qol:<br>
 			- Added tooltips on features that work outside of hex<br>
 			- Made mobile universe buttons slightly wider<br><br>
@@ -622,7 +622,7 @@ let changelog = `<h1>Changelog:</h1><br>
 			- Fixed funify unlock upgrade not autobuying.<br>
 			- Fixed singularity autocrunch not setting if set to time.<br>
 			- Fixed one of the cante puzzle questions.<br>
-			- Fixed a jinx softcap not working.<br>
+			- Fixed a jinx softcap not working.<br><br>
 	<h3>v1.8.2 - Hex Hotfix 2</h3><br>
 		Qol:<br>
 			- Changed the Uni-bar to scroll instead of using pages.<br>

--- a/js/mod.js
+++ b/js/mod.js
@@ -612,7 +612,9 @@ let changelog = `<h1>Changelog:</h1><br>
 	<h3>v1.8.3 - Hex Hotfix 3</h3><br>
 		Qol:<br>
 			- Added tooltips on features that work outside of hex<br>
-			- Made mobile universe buttons slightly wider<br><br>
+			- Made mobile universe buttons slightly wider<br>
+			- Made messages in black heart not flashbang you<br>
+			- Added tooltips to the celestialite type symbols<br><br>
 		Balancing:<br>
 			- Added a hardcap to death realm challenge's curse buff<br>
 			- Added a softcap after 6 realm challenge clears. (not that strong of a softcap though)<br><br>

--- a/js/mod.js
+++ b/js/mod.js
@@ -609,30 +609,43 @@ let credits = `<h1>Credits:</h1><br>
 		`
 
 let changelog = `<h1>Changelog:</h1><br>
+	<h3>v1.8.3 - Hex Hotfix 3</h3>
+		Qol:<br>
+			- Added tooltips on features that work outside of hex<br>
+			- Made mobile universe buttons slightly wider<br><br>
+		Balancing:<br>
+			- Added a hardcap to death realm challenge's curse buff<br>
+			- Added a softcap after 6 realm challenge clears. (not that strong of a softcap though)<br><br>
+		Bugfixes:<br>
+			- Removed player.navTab since we don't use it and some people were getting crashes due to its value corrupting. (Potentially also a very small performance improvement, but I doubt it is in any way noticeable)<br>
+			- Fixed funify unlock upgrade not autobuying.<br>
+			- Fixed singularity autocrunch not setting if set to time.<br>
+			- Fixed one of the cante puzzle questions.<br>
+			- Fixed a jinx softcap not working.<br>
 	<h3>v1.8.2 - Hex Hotfix 2</h3><br>
 		Qol:<br>
-		- Changed the Uni-bar to scroll instead of using pages.<br>
-		- Removed eclipse cooldown, cause why would you want that.<br>
-		- Added legendary pet summon pity.<br><br>
+			- Changed the Uni-bar to scroll instead of using pages.<br>
+			- Removed eclipse cooldown, cause why would you want that.<br>
+			- Added legendary pet summon pity.<br><br>
 		Balancing:<br>
-		- Lowered realm essence upgrade cost scaling.<br>
-		- Made jinx automation be unlocked earlier into hex.<br>
-		- Slightly buffed unlockable singularity effect.<br>
-		- Improved legendary pet summon odds.<br>
-		- Improved legendary gem gain from RNG rolls.<br>
-		- Improved pet point gain from summoning altar.<br><br>
+			- Lowered realm essence upgrade cost scaling.<br>
+			- Made jinx automation be unlocked earlier into hex.<br>
+			- Slightly buffed unlockable singularity effect.<br>
+			- Improved legendary pet summon odds.<br>
+			- Improved legendary gem gain from RNG rolls.<br>
+			- Improved pet point gain from summoning altar.<br><br>
 		Bugfixes:<br>
-		- Added more crash prevention.<br>
-		- Fixed break infinity not requiring an OTF slot after unlocking singularity.<br>
-		- Fixed checkback buyable cost formatting.<br><br>
+			- Added more crash prevention.<br>
+			- Fixed break infinity not requiring an OTF slot after unlocking singularity.<br>
+			- Fixed checkback buyable cost formatting.<br><br>
 		Typos:<br>
-		- Fixed fear being called anger.<br>
-		- Fixed some hex softcaps being called softlocks.<br><br>
+			- Fixed fear being called anger.<br>
+			- Fixed some hex softcaps being called softlocks.<br><br>
 	<h3>v1.8.1 - Hex Hotfix 1</h3><br>
 		Bugfixes:<br>
-		- Boons now trigger a hold tick on click<br>
-		- Fixed pet points and XPBoost being formatted incorrectly<br>
-		- Fixed edge-cases on save transfers<br><br>
+			- Boons now trigger a hold tick on click<br>
+			- Fixed pet points and XPBoost being formatted incorrectly<br>
+			- Fixed edge-cases on save transfers<br><br>
 	<h2>v1.8 - The Hexing Revamp</h2><br>
 		Content:<br>
 			- Added Universe α: Hex.<br>

--- a/js/mod.js
+++ b/js/mod.js
@@ -617,7 +617,8 @@ let changelog = `<h1>Changelog:</h1><br>
 			- Added a hardcap to death realm challenge's curse buff<br>
 			- Added a softcap after 6 realm challenge clears. (not that strong of a softcap though)<br><br>
 		Bugfixes:<br>
-			- Removed player.navTab since we don't use it and some people were getting crashes due to its value corrupting. (Potentially also a very small performance improvement, but I doubt it is in any way noticeable)<br>
+			- Removed player.navTab since we don't use it and some people were getting crashes due to its value corrupting.<br>
+			(Potentially also a very small performance improvement, but I doubt it is in any way noticeable)<br>
 			- Fixed funify unlock upgrade not autobuying.<br>
 			- Fixed singularity autocrunch not setting if set to time.<br>
 			- Fixed one of the cante puzzle questions.<br>

--- a/js/technical/canvas.js
+++ b/js/technical/canvas.js
@@ -57,8 +57,10 @@ function drawComponentBranches(layer, data, prefix) {
 function isVisibleInViewport(element) {
     let rect = element.getBoundingClientRect()
 	let par = document.documentElement.getBoundingClientRect()
-	if (document.getElementById("layerHolder").contains(element)) {
-		par = document.getElementById("layerHolder").getBoundingClientRect()
+	if (document.getElementById("layerHolder") != null) {
+		if (document.getElementById("layerHolder").contains(element)) {
+			par = document.getElementById("layerHolder").getBoundingClientRect()
+		}
 	}
 	if (document.getElementById("scrCon") != null) {
 		if (document.getElementById("scrCon").contains(element)) {

--- a/js/technical/displays.js
+++ b/js/technical/displays.js
@@ -147,7 +147,6 @@ function updateWidth() {
 	let screenWidth = window.innerWidth
 	let splitScreen = screenWidth >= 1024
 	if (options.forceOneTab) splitScreen = false
-	if (player.navTab == "none") splitScreen = true
 	tmp.other.screenWidth = screenWidth
 	tmp.other.screenHeight = window.innerHeight
 
@@ -254,7 +253,6 @@ function constructTabFormat(layer, id, family){
 
 function updateTabFormats() {
 	updateTabFormat(player.tab)
-	updateTabFormat(player.navTab)
 }
 
 function updateTabFormat(layer) {

--- a/js/technical/systemComponents.js
+++ b/js/technical/systemComponents.js
@@ -20,12 +20,7 @@ var systemComponents = {
 			v-on:click="function() {
 				if (shiftDown && options.forceTooltips) player[layer].forceTooltip = !player[layer].forceTooltip
 				else if(tmp[layer].isLayer) {
-					if (tmp[layer].leftTab) {
-						showNavTab(layer, prev)
-						showTab('none')
-					}
-					else
-						showTab(layer, prev)
+					showTab(layer, prev)
 				}
 				else {run(layers[layer].onClick, layers[layer])}
 			}"
@@ -66,12 +61,7 @@ var systemComponents = {
 		<button v-if="nodeShown(layer)"
 			v-on:click="function() {
 				if(tmp[layer].isLayer) {
-					if (tmp[layer].leftTab) {
-						showNavTab(layer, prev)
-						showTab('none')
-					}
-					else
-						showTab(layer, prev)
+					showTab(layer, prev)
 				}
 				else {run(layers[layer].onClick, layers[layer])}
 			}"

--- a/js/tree.js
+++ b/js/tree.js
@@ -1,6 +1,5 @@
 var layoutInfo = {
     startTab: "none",
-    startNavTab: "tree-tab",
 	showTree: true,
 
     treeLayout: ""
@@ -18,13 +17,3 @@ addNode("blank", {
     layerShown: "ghost",
 }, 
 )
-
-
-addLayer("tree-tab", {
-    tabFormat: 
-    [
-        ["tree", function() {return (layoutInfo.treeLayout ? layoutInfo.treeLayout : TREE_LAYERS)}]
-    ],
-    previousTab: "",
-    leftTab: true,
-})

--- a/js/utils.js
+++ b/js/utils.js
@@ -184,30 +184,14 @@ function showTab(name, prev) {
 
 }
 
-function showNavTab(name, prev) {
-	console.log(prev)
-	if (LAYERS.includes(name) && !layerunlocked(name)) return
-	if (player.navTab !== name) clearParticles(function(p) {return p.layer === player.navTab})
-	if (tmp[name] && tmp[name].previousTab !== undefined) prev = tmp[name].previousTab
-	var toTreeTab = name == "tree-tab"
-	console.log(name + prev)
-	if (name!== "none" && prev && !tmp[prev]?.leftTab == !tmp[name]?.leftTab) player[name].prevTab = prev
-	else if (player[name])
-		player[name].prevTab = ""
-	player.navTab = name
-	updateTabFormats()
-	needCanvasUpdate = true
-}
-
 
 function goBack(layer) {
 	let nextTab = "none"
 
 	if (player[layer].prevTab) nextTab = player[layer].prevTab
-	if (player.navTab === "none" && (tmp[layer]?.row == "side" || tmp[layer].row == "otherside")) nextTab = player.lastSafeTab
+	if (tmp[layer]?.row == "side" || tmp[layer].row == "otherside") nextTab = player.lastSafeTab
 
-	if (tmp[layer].leftTab) showNavTab(nextTab, layer)
-	else showTab(nextTab, layer)
+	showTab(nextTab, layer)
 
 }
 

--- a/js/utils/easyAccess.js
+++ b/js/utils/easyAccess.js
@@ -103,11 +103,12 @@ function buyableEffect(layer, id) {
 }
 
 function levelableEffect(layer, id) {
-	if (layer != "pet" || ((player.points.gte(1e100) || hasMilestone("ip", 24) || (hasUpgrade("de", 13) && inChallenge("tad", 11))) && !inChallenge("ip", 13))) {
-		return (tmp[layer].levelables[id].effect)
-	} else {
-		return [new Decimal(1), new Decimal(1), new Decimal(1), new Decimal(1)]
+	if (layer != "pet") {
+		if ((player.points.gte(1e100) || hasMilestone("ip", 24) || (hasUpgrade("de", 13) && inChallenge("tad", 11))) && !inChallenge("ip", 13)) {
+			return (tmp[layer].levelables[id].effect)
+		}
 	}
+	return [new Decimal(1), new Decimal(1), new Decimal(1), new Decimal(1)]
 }
 
 function clickableEffect(layer, id) {

--- a/js/utils/save.js
+++ b/js/utils/save.js
@@ -9,7 +9,6 @@ function save(force) {
 function startPlayerBase() {
 	return {
 		tab: layoutInfo.startTab,
-		navTab: (layoutInfo.showTree ? layoutInfo.startNavTab : "none"),
 		time: Date.now(),
 		notify: {},
 		versionType: modInfo.id,


### PR DESCRIPTION
<h3>v1.8.3 - Hex Hotfix 3</h3>
Qol:<br>
- Added tooltips on features that work outside of hex<br>
- Made mobile universe buttons slightly wider<br><br>
Balancing:<br>
- Added a hardcap to death realm challenge's curse buff<br>
- Added a softcap after 6 realm challenge clears. (not that strong of a softcap though)<br><br>
Bugfixes:<br>
- Removed player.navTab since we don't use it and some people were getting crashes due to its value corrupting. (Potentially also a very small performance improvement, but I doubt it is in any way noticeable)<br>
- Fixed funify unlock upgrade not autobuying.<br>
- Fixed singularity autocrunch not setting if set to time.<br>
- Fixed one of the cante puzzle questions.<br>
- Fixed a jinx softcap not working.<br>