### PR TITLE
v1.12.1

### DIFF
--- a/css/general-style.css
+++ b/css/general-style.css
@@ -34,3 +34,7 @@ h1, h2, h3, b, input {
 	color: #ffffff;
 	text-shadow: 0 0 10px #ffffff;
 }
+
+.noStyle {
+	all: revert;
+}

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
 				</div>
 			</transition-group>
 		</div>
-		<div class="particle-container">
+		<div id="particleHolder" class="particle-container">
 				<div v-for="particle,index in particles">
 					<particle :data="particle" :index="index" v-bind:key="'b' + particle.id"></particle>
 				</div>

--- a/js/AltU2/altUni2.js
+++ b/js/AltU2/altUni2.js
@@ -42,7 +42,7 @@
             player.subtabs["au2"]['stuff'] = 'Main'
         }
 
-        player.au2.starsToGet = Decimal.mul(player.ro.rocketParts, player.ro.activatedFuel.pow(0.3)).floor()
+        player.au2.starsToGet = Decimal.mul(player.ro.rocketParts, player.ro.activatedFuel.pow(0.5)).floor()
         player.au2.starsToGet = player.au2.starsToGet.mul(levelableEffect("st", 209)[0]).floor()
         player.au2.starsToGet = player.au2.starsToGet.mul(buyableEffect("st", 201)).floor()
         player.au2.starsToGet = player.au2.starsToGet.mul(buyableEffect("depth3", 3)).floor()
@@ -54,12 +54,12 @@
         //Star Softcap
         player.au2.starSoftcapStart = new Decimal(1000000)
 
-        let softcapBase = new Decimal(0.5)
+        let softcapBase = new Decimal(0.4)
         if (player.alephsChamber.milestone[25] > 0) softcapBase = softcapBase.add(0.1)
 
         if (player.au2.starsToGet.gte(player.au2.starSoftcapStart)) {
             player.au2.starSoftcapEffect = softcapBase.div(Decimal.div(player.au2.starsToGet.add(1).log(2).add(100), 100))
-            player.au2.starsToGet = player.au2.starsToGet.sub(player.au2.starSoftcapStart).pow(player.au2.starSoftcapEffect).add(player.au2.starSoftcapStart)
+            player.au2.starsToGet = player.au2.starsToGet.div(player.au2.starSoftcapStart).pow(player.au2.starSoftcapEffect).mul(player.au2.starSoftcapStart)
             player.au2.starSoftcapActive = true  
         } else
         {

--- a/js/AltU2/exploration.js
+++ b/js/AltU2/exploration.js
@@ -149,7 +149,7 @@ addLayer("se", {
         },
         11: {
             title() { return "A0" },
-            tooltip() { return "Visited " + formatWhole(player.se.starsExploreCount[0][0].min(100)) + "/100 times.<br>Boosts star gain by x" + format(player.se.starsExploreEffect[0][0]) + "." },
+            tooltip() { return "Visited " + formatWhole(player.se.starsExploreCount[0][0].min(100)) + "/100 times.<br>Boosts star gain by x" + format(player.se.starsExploreEffect[0][0]) + ".<br><small>(Ignoring Softcap)</small>" },
             canClick() { 
                 return (player.se.currentPosition[0].eq(0) && player.se.currentPosition[1].eq(1)) && !player.se.currentlyTravelling || (player.se.currentPosition[0].eq(1) && player.se.currentPosition[1].eq(0)) && !player.se.currentlyTravelling
             },

--- a/js/AltU2/iridite.js
+++ b/js/AltU2/iridite.js
@@ -335,7 +335,7 @@ addLayer("ir", {
             image() { return this.canClick() ? "resources/ships/cruiser.png" : "resources/secret.png"},
             title() { return "Cruiser" },
             description() {
-                return "x" + format(this.effect()[0]) + " to stars.<br>x" + format(this.effect()[1]) + " to singularity points.<br>x" + format(this.effect()[2]) + " to ship damage.<br>x" + format(this.effect()[3]) + " to ship health.<br>"
+                return "x" + format(this.effect()[0]) + " to stars. <small>(Ignoring Softcap)</small><br>x" + format(this.effect()[1]) + " to singularity points.<br>x" + format(this.effect()[2]) + " to ship damage.<br>x" + format(this.effect()[3]) + " to ship health.<br>"
             },
             lore() {
                 return "Fast, slim, and rapid-firing bullets. Pretty average ship ngl."

--- a/js/AltU2/spaceBuildings.js
+++ b/js/AltU2/spaceBuildings.js
@@ -69,7 +69,7 @@
             purchaseLimit() {return buyableEffect("sb", 12)},
             currency() { return player.ir.spaceRock},
             pay(amt) { player.ir.spaceRock = this.currency().sub(amt) },
-            effect(x) { return getBuyableAmount(this.layer, this.id).add(1).pow(5).pow(player.sb.sseEffect) },
+            effect(x) { return getBuyableAmount(this.layer, this.id).add(1).pow(4).pow(player.sb.sseEffect) },
             unlocked() { return true },
             cost(x) { return this.costGrowth().pow(x || getBuyableAmount(this.layer, this.id)).mul(this.costBase()).floor() },
             canAfford() { return this.currency().gte(this.cost()) },
@@ -78,6 +78,7 @@
             },
             display() {
                 return "Boosts star gain by x" + format(tmp[this.layer].buyables[this.id].effect) + ".\n\
+                    <small>(Ignoring Softcap)</small>\n\
                     Cost: " + formatWhole(tmp[this.layer].buyables[this.id].cost) + " Space Rocks"
             },
             buy(mult) {

--- a/js/Black Heart/alephsChamber.js
+++ b/js/Black Heart/alephsChamber.js
@@ -74,6 +74,7 @@ addLayer("alephsChamber", {
                     ["raw-html", "<u>Effects</u>", {color: "var(--textColor)", fontSize: "20px", fontFamily: "monospace"}],
                     ["raw-html", () => { return "Weakened Star Softcap." }, {color: "var(--textColor)", fontSize: "18px", fontFamily: "monospace"}],
                     ["raw-html", () => { return "Improved SP's effect on singularity gain." }, {color: "var(--textColor)", fontSize: "18px", fontFamily: "monospace"}],
+                    ["raw-html", () => { return "Tav's Domain Expander cap now increments by x1e5"}, {color: "var(--textColor)", fontSize: "18px", fontFamily: "monospace"}],
                     ["raw-html", () => { return "x36 Hex Power." }, {color: "var(--textColor)", fontSize: "18px", fontFamily: "monospace"}],
                     ["raw-html", () => { return "x100 Infinitum." }, {color: "var(--textColor)", fontSize: "18px", fontFamily: "monospace"}],
                     ["raw-html", () => { return "x10 Emotions." }, {color: "var(--textColor)", fontSize: "18px", fontFamily: "monospace"}],

--- a/js/Black Heart/blackHeart.js
+++ b/js/Black Heart/blackHeart.js
@@ -171,6 +171,7 @@ addLayer("bh", {
             mending: new Decimal(0),
             potency: new Decimal(0),
             shield: new Decimal(0), // Not same as previous, is a prevent damage stack
+            shieldDecay: new Decimal(0),
             stun: ["none", new Decimal(0)],
             randomMult: new Decimal(1),
             curAdd: new Decimal(1),
@@ -221,6 +222,7 @@ addLayer("bh", {
                 mending: new Decimal(0),
                 potency: new Decimal(0),
                 shield: new Decimal(0),
+                shieldDecay: new Decimal(0),
                 stun: ["none", new Decimal(0)],
                 attributes: {},
                 actionChances: [],
@@ -276,6 +278,7 @@ addLayer("bh", {
                 mending: new Decimal(0),
                 potency: new Decimal(0),
                 shield: new Decimal(0),
+                shieldDecay: new Decimal(0),
                 stun: ["none", new Decimal(0)],
                 attributes: {},
                 actionChances: [],
@@ -331,6 +334,7 @@ addLayer("bh", {
                 mending: new Decimal(0),
                 potency: new Decimal(0),
                 shield: new Decimal(0),
+                shieldDecay: new Decimal(0),
                 stun: ["none", new Decimal(0)],
                 attributes: {},
                 actionChances: [],
@@ -556,6 +560,7 @@ addLayer("bh", {
         comboScalingStart: new Decimal(100),
         comboScalingReduction: 0,
         comboSoftcap: new Decimal(1),
+        shieldDecayMax: new Decimal(30),
         timer: new Decimal(0),
         timerStop: false,
         timeSpeed: new Decimal(1),
@@ -717,6 +722,9 @@ addLayer("bh", {
         player.bh.comboSoftcap = new Decimal(1)
         if (player.bh.combo.gte(player.bh.comboScalingStart)) player.bh.comboSoftcap = Decimal.pow(player.bh.comboScaling, player.bh.combo.sub(player.bh.comboScalingStart))
 
+        player.bh.shieldDecayMax = new Decimal(20)
+        if (BHS[player.bh.currentStage].shieldDecayMax) player.bh.shieldDecayMax = BHS[player.bh.currentStage].shieldDecayMax
+
         if (player.subtabs["bh"]["stuff"] == "bullet") {
             player.bh.bulletHell = true
         } else {
@@ -782,6 +790,16 @@ addLayer("bh", {
                         if (player.bh.celestialite.stun.length >= 3 && player.bh.celestialite.stun[1].lte(0)) {
                             bhAction(3, player.bh.celestialite.stun[2], false, 1, true)
                         }
+                    }
+                    
+                    if (player.bh.celestialite.shield.gt(0)) {
+                        player.bh.celestialite.shieldDecay = player.bh.celestialite.shieldDecay.add(delta)
+                        if (player.bh.celestialite.shieldDecay.gte(player.bh.shieldDecayMax)) {
+                            player.bh.celestialite.shieldDecay = new Decimal(0)
+                            player.bh.celestialite.shield = player.bh.celestialite.shield.sub(1).max(0)
+                        }
+                    } else if (player.bh.celestialite.shieldDecay.gt(0)) {
+                        player.bh.celestialite.shieldDecay = new Decimal(0)
                     }
                 }
 
@@ -914,6 +932,16 @@ addLayer("bh", {
                         if (player.bh.characters[i].stun.length >= 3 && player.bh.characters[i].stun[1].lte(0)) {
                             bhAction(i, player.bh.characters[i].stun[2], false, 1, true)
                         }
+                    }
+                    
+                    if (player.bh.characters[i].shield.gt(0)) {
+                        player.bh.characters[i].shieldDecay = player.bh.characters[i].shieldDecay.add(delta)
+                        if (player.bh.characters[i].shieldDecay.gte(player.bh.shieldDecayMax)) {
+                            player.bh.characters[i].shieldDecay = new Decimal(0)
+                            player.bh.characters[i].shield = player.bh.characters[i].shield.sub(1).max(0)
+                        }
+                    } else if (player.bh.characters[i].shieldDecay.gt(0)) {
+                        player.bh.characters[i].shieldDecay = new Decimal(0)
                     }
                 }
 

--- a/js/Black Heart/blackHeartFunctions.js
+++ b/js/Black Heart/blackHeartFunctions.js
@@ -912,6 +912,8 @@ function BHStageEnter(stage) {
 
     for (let i = 0; i < 3; i++) {
         player.bh.characters[i].health = player.bh.characters[i].maxHealth
+        player.bh.characters[i].shield = new Decimal(0)
+        player.bh.characters[i].stun = ["none", new Decimal(0)]
 
         for (let j = 0; j < 4; j++) {
             player.bh.characters[i].skills[j].cooldown = player.bh.characters[i].skills[j].cooldownMax

--- a/js/Black Heart/blackHeartFunctions.js
+++ b/js/Black Heart/blackHeartFunctions.js
@@ -998,6 +998,16 @@ function stagnantUpdate(time) {
                             bhAction(3, player.bh.celestialite.stun[2], false, 1, true)
                         }
                     }
+
+                    if (player.bh.celestialite.shield.gt(0)) {
+                        player.bh.celestialite.shieldDecay = player.bh.celestialite.shieldDecay.add(delta)
+                        if (player.bh.celestialite.shieldDecay.gte(player.bh.shieldDecayMax)) {
+                            player.bh.celestialite.shieldDecay = new Decimal(0)
+                            player.bh.celestialite.shield = player.bh.celestialite.shield.sub(1).max(0)
+                        }
+                    } else if (player.bh.celestialite.shieldDecay.gt(0)) {
+                        player.bh.celestialite.shieldDecay = new Decimal(0)
+                    }
                     
                     // Cycle, increment cooldowns, and trigger celestialite actions
                     for (let i = 0; i < 4; i++) {
@@ -1066,6 +1076,16 @@ function stagnantUpdate(time) {
                         if (player.bh.characters[i].stun.length >= 3 && player.bh.characters[i].stun[1].lte(0)) {
                             bhAction(i, player.bh.characters[i].stun[2], false, 1, true)
                         }
+                    }
+                    
+                    if (player.bh.characters[i].shield.gt(0)) {
+                        player.bh.characters[i].shieldDecay = player.bh.characters[i].shieldDecay.add(delta)
+                        if (player.bh.characters[i].shieldDecay.gte(player.bh.shieldDecayMax)) {
+                            player.bh.characters[i].shieldDecay = new Decimal(0)
+                            player.bh.characters[i].shield = player.bh.characters[i].shield.sub(1).max(0)
+                        }
+                    } else if (player.bh.characters[i].shieldDecay.gt(0)) {
+                        player.bh.characters[i].shieldDecay = new Decimal(0)
                     }
 
                     // Cycle through character skills

--- a/js/Black Heart/bulletHell.js
+++ b/js/Black Heart/bulletHell.js
@@ -41,6 +41,7 @@ function bulletHell(actions, values = {}, exitAction = () => {}) {
 
     // Check if tabbed in, if not just deal a bunch of damage
     if (player && player.tab && player.tab != "bh") {
+        if (player.bh.celestialite.health.lte(0)) return
         if (!BHS[player.bh.currentStage].timeStagnation) {
             for (let i = 0; i < 3; i++) {
                 player.bh.characters[i].stun = ["hard", new Decimal(info.duration)]
@@ -68,6 +69,7 @@ function bulletHell(actions, values = {}, exitAction = () => {}) {
     if (old) old.remove()
 
     if (player.subtabs["bh"]["stuff"] != "bullet") {
+        if (player.bh.celestialite.health.lte(0)) return
         player.subtabs["bh"]["stuff"] = "bullet";
         pauseUniverseAll(["BH"], "pause", true)
         options.fullscreen = true
@@ -253,13 +255,14 @@ function bulletHell(actions, values = {}, exitAction = () => {}) {
         const dx = playerGlobalX - bx;
         const dy = playerGlobalY - by;
         const dist = Math.sqrt(dx * dx + dy * dy);
+        const bulletRadius = info.actions[id].bulletRadius ?? 10
         if (dist === 0) return;
         info.bullets.push({
             x: bx,
             y: by,
             vx: (dx / dist) * speed,
             vy: (dy / dist) * speed,
-            r: 10,
+            r: bulletRadius,
             draw(b, bossCtx) {
                 bossCtx.beginPath();
                 bossCtx.arc(b.x, b.y, b.r, 0, 2 * Math.PI);
@@ -291,8 +294,8 @@ function bulletHell(actions, values = {}, exitAction = () => {}) {
 
     // Shoot spread at coordinates
     info.shootSpreadAtPlayer = (bx, by, id) => {
-        let dx = info.px - bx;
-        let dy = info.py - by;
+        let dx = info.px - bx + info.boxLeft;
+        let dy = info.py - by + info.boxTop;
         let baseAngle = Math.atan2(dy, dx);
         for (let i = 0; i < info.actions[id].spreadCount; i++) {
             let angle = baseAngle + (i - (info.actions[id].spreadCount - 1) / 2) * (info.actions[id].spreadAngle / (info.actions[id].spreadCount - 1));
@@ -758,7 +761,7 @@ function bulletHell(actions, values = {}, exitAction = () => {}) {
                 const dx = Math.cos(b.angle), dy = Math.sin(b.angle);
                 // Project player onto knife axis
                 const t = ((playerX - b.x) * dx + (playerY - b.y) * dy);
-                if (t >= 0 && t <= b.r) {
+                if (t >= -b.r+info.pr && t <= b.r - info.pr) {
                     // Perpendicular distance
                     const perp = Math.abs((playerX - b.x) * dy - (playerY - b.y) * dx);
                     if (perp < info.pr + b.width / 2) {
@@ -1033,6 +1036,7 @@ if (storedInfo && storedInfo != "") {
 BHB.diamondAttack = {
     //bulletHell({"diamondAttack": {diamondAmount: 2, intervalDiv: 1}}, {duration: 10})
     codeFunc(info, id) {
+        const diamondRadius = info.actions[id].diamondRadius ?? 40;
         for (let i = 0; i < info.actions[id].diamondAmount; i++) {
             let angleOffset = (2 * Math.PI * i) / info.actions[id].diamondAmount;
             info.bullets.push({
@@ -1041,7 +1045,7 @@ BHB.diamondAttack = {
                 y: info.boxTop + info.py + 200 * Math.sin(angleOffset),
                 vx: 0,
                 vy: 0,
-                r: 40,
+                r: diamondRadius,
                 orbitRadius: 200,
                 orbitAngle: angleOffset,
                 orbitSpeed: 0.015 + 0.003 * i, // slightly different speeds
@@ -1081,9 +1085,10 @@ BHB.diamondAttack = {
                 b.y += (targetBy - b.y) * lerpFactor;
 
                 // Each diamond shoots at its own interval
+                const speed = info.actions[id].enemySpeed ?? 5
                 if (!b.lastShotTime) b.lastShotTime = ticks;
                 if (ticks - b.lastShotTime > b.shootInterval) {
-                    info.shootAtPlayer(b.x, b.y, id);
+                    info.shootAtPlayer(b.x, b.y, id, speed);
                     b.lastShotTime = ticks;
                 }
             }
@@ -1149,8 +1154,8 @@ BHB.bulletRain = {
     //bulletHell({"bulletRain": {bulletPerSec: 10}}, {duration: 12})
     moveFunc(info, ticks, id) {
         // Rain Bullets
-        const bulletRadius = 12;
-        const bulletSpeed = 4;
+        const bulletRadius = info.actions[id].bulletRadius ?? 12;
+        const bulletSpeed = info.actions[id].enemySpeed ?? 4;
         if (!info.actions[id].lastTime) info.actions[id].lastTime = ticks;
         const bulletsToSpawn = Math.floor(((ticks - info.actions[id].lastTime) / 1000) * info.actions[id].bulletPerSec); // LAST NUMBER IS AMOUNT OF BULLETS PER SECOND
         for (let i = 0; i < bulletsToSpawn; i++) {
@@ -1168,7 +1173,7 @@ BHB.inverseRain = {
     //bulletHell({"inverseRain": {bulletPerSec: 10}}, {duration: 12})
     moveFunc(info, ticks, id) {
         // Rain Bullets
-        const bulletRadius = 12;
+        const bulletRadius = info.actions[id].bulletRadius ?? 12;
         const bulletSpeed = 4;
         if (!info.actions[id].lastTime) info.actions[id].lastTime = ticks;
         const bulletsToSpawn = Math.floor(((ticks - info.actions[id].lastTime) / 1000) * info.actions[id].bulletPerSec); // LAST NUMBER IS AMOUNT OF BULLETS PER SECOND
@@ -1434,7 +1439,7 @@ BHB.centerSpreadAttack = {
     moveFunc(info, ticks, id) {
         if (!info.actions[id].lastTime) info.actions[id].lastTime = ticks;
         if (ticks - info.actions[id].lastTime > info.actions[id].spreadInterval) {
-            info.shootSpreadAtPlayer(info.width / 2, info.height / 2, id);
+            info.shootSpreadAtPlayer(info.width / 2 + info.boxLeft, info.height / 2 + info.boxTop, id);
             info.actions[id].lastTime = ticks;
         }
 
@@ -1447,7 +1452,7 @@ BHB.centerSingleAttack = {
     moveFunc(info, ticks, id) {
         if (!info.actions[id].lastTime) info.actions[id].lastTime = ticks;
         if (ticks - info.actions[id].lastTime > info.actions[id].shootInterval) {
-            info.shootAtPlayer(info.width / 2, info.height / 2, id, info.actions[id].bulletSpeed);
+            info.shootAtPlayer(info.width / 2 + info.boxLeft, info.height / 2 + info.boxTop, id, info.actions[id].bulletSpeed);
             info.actions[id].lastTime = ticks;
         }
 

--- a/js/Black Heart/laboratory.js
+++ b/js/Black Heart/laboratory.js
@@ -246,7 +246,7 @@ addLayer("laboratory", {
             description: "Unlock a 6th starmetal essence generator.",
             cost: new Decimal(256),
             currencyLocation() { return player.laboratory },
-            currencyDisplayName: "Matos Dust",
+            currencyDisplayName: "Matos Shards",
             currencyInternalName: "matosShard",
             style() {
                 let look = {minHeight: "100px", borderRadius: "15px", color: "white", border: "2px solid rgba(0,0,0,0.5)", margin: "2px"}

--- a/js/Black Heart/matosLair.js
+++ b/js/Black Heart/matosLair.js
@@ -244,9 +244,9 @@ BHC.m03 = {
         borderColor: "#2F2F2F",
         fontSize: "60px",
     },
-    health: new Decimal(150),
+    health: new Decimal(160),
     damage: new Decimal(10),
-    regen: new Decimal(5),
+    regen: new Decimal(6),
     actions: {
         0: {
             name: "Quick Shot",
@@ -575,7 +575,7 @@ BHC.matos = {
     name: "Matos",
     icon: "resources/matos.png",
     health: new Decimal(7500),
-    damage: new Decimal(6),
+    damage: new Decimal(10),
     noRandomStats: true,
     immortal: true,
     actions: {

--- a/js/Black Heart/matosLair.js
+++ b/js/Black Heart/matosLair.js
@@ -246,7 +246,7 @@ BHC.m03 = {
     },
     health: new Decimal(150),
     damage: new Decimal(10),
-    regen: new Decimal(10),
+    regen: new Decimal(5),
     actions: {
         0: {
             name: "Quick Shot",
@@ -683,7 +683,7 @@ BHC.matos = {
                 if (player.bh.celestialite.health.lt(2500) && player.bh.celestialite.attackID == 9) {
                     screenFlash("NOVA WILL BRING US GLORY.", 3000)
                     setTimeout(() => {
-                        bulletHell({}, {width: 750, duration: 20, timed: true, cellSize: 50, start: "cell", goal: "cell"})
+                        bulletHell({}, {width: 750, duration: 30, timed: true, cellSize: 50, start: "cell", goal: "cell"})
                     }, 3000)
                     player.bh.celestialite.attackID += 1
                 }
@@ -710,7 +710,7 @@ BHC.matos = {
                         } else if (random > 0.2 && random < 0.4) {
                             bulletHell({"bulletRain": {bulletPerSec: 7}, "knifeThrow": {knifeLength: 64, knifeWidth: 16, enemySpeed: 6, knifePerSec: 1.5}}, {duration: 15})
                         } else if (random > 0.4 && random < 0.6) {
-                            bulletHell({}, {width: 750, duration: 20, timed: true, cellSize: 50, start: "cell", goal: "cell"})
+                            bulletHell({}, {width: 750, duration: 30, timed: true, cellSize: 50, start: "cell", goal: "cell"})
                         } else if (random > 0.6 && random < 0.7) {
                             bulletHell({"knifeThrow": {knifeLength: 64, knifeWidth: 16, enemySpeed: 6, knifePerSec: 2}}, {width: 800, height: 500, duration: 15, subArena: true, subWidth: 300})
                         } else  {
@@ -728,7 +728,7 @@ BHC.matos = {
                         } else if (random > 0.2 && random < 0.4) {
                             bulletHell({"bulletRain": {bulletPerSec: 7}, "knifeThrow": {knifeLength: 64, knifeWidth: 16, enemySpeed: 6, knifePerSec: 1.5}}, {duration: 15})
                         } else if (random > 0.4 && random < 0.6) {
-                            bulletHell({}, {width: 750, duration: 20, timed: true, cellSize: 50, start: "cell", goal: "cell"})
+                            bulletHell({}, {width: 750, duration: 30, timed: true, cellSize: 50, start: "cell", goal: "cell"})
                         } else if (random > 0.6 && random < 0.7) {
                             bulletHell({"knifeThrow": {knifeLength: 64, knifeWidth: 16, enemySpeed: 6, knifePerSec: 2}}, {width: 800, height: 500, duration: 15, subArena: true, subWidth: 300})
                         } else  {

--- a/js/Black Heart/skills.js
+++ b/js/Black Heart/skills.js
@@ -291,7 +291,7 @@ BHA.kres_berserker = {
 
 // Nav Skills
 BHA.nav_magicMissle = {
-    name: "Magic Missle",
+    name: "Magic Missile",
     description() {return "Deals " + formatWhole(new Decimal(100).add(player.bh.skillData["nav_magicMissle"].level.mul(20))) + "% magic damage"},
     passiveText() {return "+" + formatSimple(player.bh.skillData["nav_magicMissle"].maxLevel.div(5)) + " DMG"},
     char: "nav",

--- a/js/Black Heart/skills.js
+++ b/js/Black Heart/skills.js
@@ -134,7 +134,7 @@ BHA.general_block = {
         "defenseAdd"() {return new Decimal(25).add(player.bh.skillData["general_block"].level.mul(5))}, // Multiplicative Effect
     },
     duration: new Decimal(10),
-    cooldown: new Decimal(25),
+    cooldown: new Decimal(20),
     cooldownCap: new Decimal(5),
 }
 BHA.general_poisonNeedle = {
@@ -581,7 +581,7 @@ BHA.eclipse_lightBarrier = {
     description() {
         let time = "time"
         if (new Decimal(1).add(player.bh.skillData["eclipse_lightBarrier"].level.mul(0.2).floor()).neq(1)) time = "times"
-        let str = "Soft-stuns you for " + formatTime(new Decimal(8).sub(player.bh.skillData["eclipse_lightBarrier"].level.modulo(5).div(2))) + ", then shield all players " + formatWhole(new Decimal(1).add(player.bh.skillData["eclipse_lightBarrier"].level.mul(0.2).floor())) + " " + time
+        let str = "Soft-stuns you for " + formatTime(new Decimal(6).sub(player.bh.skillData["eclipse_lightBarrier"].level.modulo(5).div(2))) + ", then shield all players " + formatWhole(new Decimal(1).add(player.bh.skillData["eclipse_lightBarrier"].level.mul(0.2).floor())) + " " + time
         return str
     },
     passiveText() {return "+" + formatSimple(player.bh.skillData["eclipse_lightBarrier"].maxLevel.div(2)) + " DEF"},
@@ -596,9 +596,9 @@ BHA.eclipse_lightBarrier = {
     type: "shield",
     target: "allPlayer",
     value() {return new Decimal(1).add(player.bh.skillData["eclipse_lightBarrier"].level.mul(0.2).floor())},
-    stun() {return ["soft", new Decimal(8).sub(player.bh.skillData["eclipse_lightBarrier"].level.modulo(5).div(2)), player.bh.skillData["eclipse_lightBarrier"].selected[1]]},
-    cooldown: new Decimal(30),
-    cooldownCap: new Decimal(10),
+    stun() {return ["soft", new Decimal(6).sub(player.bh.skillData["eclipse_lightBarrier"].level.modulo(5).div(2)), player.bh.skillData["eclipse_lightBarrier"].selected[1]]},
+    cooldown: new Decimal(20),
+    cooldownCap: new Decimal(5),
 }
 BHA.eclipse_solarRetinopathy = {
     name: "Solar Retinopathy",

--- a/js/Black Heart/stagnantSynestia.js
+++ b/js/Black Heart/stagnantSynestia.js
@@ -213,7 +213,7 @@ addLayer("stagnantSynestia", {
             canAfford() {return this.currency().gte(this.cost())},
             display() {
                 return "<h3>Iridian Boost</h3> (" + formatWhole(getBuyableAmount(this.layer, this.id)) + "/10)\n\
-                    Boost star gain\n\
+                    Boost star gain (Ignoring softcap)\n\
                     Currently: x" + formatSimple(tmp[this.layer].buyables[this.id].effect) + "\n\ \n\
                     Cost: " + formatWhole(tmp[this.layer].buyables[this.id].cost) + "<br>Temporal Dust"
             },
@@ -304,7 +304,7 @@ addLayer("stagnantSynestia", {
                         ["raw-html", () => {return "Boosts check back xp by x" + formatSimple(player.stagnantSynestia.comboEffect, 2)}, {color: "var(--textColor)", fontSize: "12px", fontFamily: "monospace"}],
                     ], {width: "272px", height: "25px"}],
                     ["style-column", [
-                        ["raw-html", () => {return "<p style='line-height:1.2'>Milestones multiply time speed during respawn by x" + formatSimple(player.stagnantSynestia.milestoneEffect, 2)}, {color: "var(--textColor)", fontSize: "12px", fontFamily: "monospace"}],
+                        ["raw-html", () => {return "<p style='line-height:1.2'>Milestones multiply tickspeed during celestialite respawn by x" + formatSimple(player.stagnantSynestia.milestoneEffect, 2)}, {color: "var(--textColor)", fontSize: "12px", fontFamily: "monospace"}],
                     ], {width: "272px", height: "47px", background: "var(--layerBackground)", borderTop: "3px solid var(--regBorder)"}],
                 ], {width: "272px", height: "114px", background: "var(--miscButtonHover)", borderBottom: "3px solid var(--regBorder)"}],
                 ["theme-scroll-column", [
@@ -372,7 +372,12 @@ BHC.staticAlpha = {
             type: "function",
             target: "allPlayer",
             onTrigger(index, slot, target, magnitude) {
-                bulletHell({"bulletRain": {bulletPerSec: 10+(magnitude*2)}}, {width: 800, height: 500, duration: 7+magnitude, subArena: true, subWidth: 300-(magnitude*20), subHeight: 300-(magnitude*20)})
+                let random = Math.random()
+                if (random < 0.5) {
+                    bulletHell({"bulletRain": {bulletPerSec: 10+(magnitude*2)}}, {width: 800, height: 500, duration: 7+magnitude, subArena: true, subWidth: 300-(magnitude*20), subHeight: 300-(magnitude*20)})
+                } else {
+                    bulletHell({"bulletRain": {bulletPerSec: 4+magnitude, bulletRadius: 18+(magnitude*2)}}, {width: 250, height: 250, duration: 7+magnitude})
+                }
             },
             cooldown: new Decimal(5),
         },
@@ -417,7 +422,12 @@ BHC.staticBeta = {
             type: "function",
             target: "allPlayer",
             onTrigger(index, slot, target, magnitude) {
-                bulletHell({"knifeThrow": {knifeLength: 64, knifeWidth: 16, enemySpeed: 2+(magnitude/8), knifePerSec: 2+(magnitude/8)}}, {width: 500, height: 300, duration: 7+magnitude})
+                let random = Math.random()
+                if (random < 0.5) {
+                    bulletHell({"knifeThrow": {knifeLength: 64, knifeWidth: 16, enemySpeed: 2+(magnitude/8), knifePerSec: 2+(magnitude/8)}}, {width: 500, height: 300, duration: 7+magnitude})
+                } else {
+                    bulletHell({"radialKnifeBurstAttack": {knifeLength: 64, knifeWidth: 16, burstInterval: 1500-(magnitude*100), bulletsPerBurst: 5, enemySpeed: 3+(magnitude/8)}}, {width: 400, height: 400, duration: 7+magnitude})
+                }
             },
             cooldown: new Decimal(6),
         },
@@ -471,7 +481,12 @@ BHC.staticGamma = {
             type: "function",
             target: "allPlayer",
             onTrigger(index, slot, target, magnitude) {
-                bulletHell({"diamondAttack": {diamondAmount: 1, intervalDiv: 1+(magnitude/10)}}, {width: 100, height: 100, duration: 7+magnitude})
+                let random = Math.random()
+                if (random < 0.5) {
+                    bulletHell({"diamondAttack": {diamondAmount: 1, intervalDiv: 0.75+(magnitude/8)}}, {width: 100, height: 100, duration: 7+magnitude})
+                } else {
+                    bulletHell({"diamondAttack": {diamondAmount: 1, diamondRadius: 50, bulletRadius: 15, enemySpeed: 3+(magnitude/5), intervalDiv: 0.75+(magnitude/8)}}, {width: 100, height: 100, duration: 7+magnitude})
+                }
             },
             cooldown: new Decimal(9),
         },
@@ -507,7 +522,8 @@ BHC.staticDelta = {
             type: "function",
             target: "allPlayer",
             onTrigger(index, slot, target, magnitude) {
-                bulletHell({"bulletRain": {bulletPerSec: 4+magnitude}, "inverseRain": {bulletPerSec: 4+magnitude}}, {duration: 7+magnitude})
+                let speedDist = 3 * Math.random()
+                bulletHell({"bulletRain": {bulletPerSec: (4+speedDist)*((magnitude/4)+1), enemySpeed: 3+(Math.random()*2)}, "inverseRain": {bulletPerSec: (4-speedDist)*((magnitude/4)+1), enemySpeed: 3+(Math.random()*2)}}, {duration: 7+magnitude})
             },
             cooldown: new Decimal(3.5),
         },
@@ -561,7 +577,12 @@ BHC.staticEpsilon = {
             type: "function",
             target: "allPlayer",
             onTrigger(index, slot, target, magnitude) {
-                bulletHell({"knifeThrow": {knifeLength: 64, knifeWidth: 16, enemySpeed: 6, knifePerSec: 1+(magnitude/5)}}, {duration: 10+(magnitude*2), start: "left", subArena: true, subWidth: 250, subHeight: 500, subMove: "right", subSpeed: 0.5})
+                let random = Math.random()
+                if (random < 0.5) {
+                    bulletHell({"knifeThrow": {knifeLength: 64, knifeWidth: 16, enemySpeed: 6, knifePerSec: 1+(magnitude/5)}}, {duration: 10+(magnitude*2), start: "left", subArena: true, subWidth: 250, subHeight: 500, subMove: "right", subSpeed: 0.5})
+                } else {
+                    bulletHell({"knifeThrow": {knifeLength: 64, knifeWidth: 16, enemySpeed: 5, knifePerSec: 1+(magnitude/5)}}, {duration: 10+(magnitude*2), subArena: true, subWidth: 250, subHeight: 250, subSpeed: 0.5})
+                }
             },
             cooldown: new Decimal(10),
         },
@@ -597,7 +618,8 @@ BHC.staticZeta = {
             type: "function",
             target: "allPlayer",
             onTrigger(index, slot, target, magnitude) {
-                bulletHell({"movingCircleRadialBurstAttack": {circleAmount: 3, burstInterval: 1300-(magnitude*100), bulletsPerBurst: 6, enemySpeed: 3, bulletSpeed: 3}}, {duration: 7+magnitude})
+                let speedDist = 2 * Math.random()
+                bulletHell({"movingCircleRadialBurstAttack": {circleAmount: Math.round(4+speedDist), burstInterval: 1300-(magnitude*100), bulletsPerBurst: Math.round(4-speedDist), enemySpeed: 3, bulletSpeed: 3}}, {duration: 7+magnitude})
             },
             cooldown: new Decimal(5),
         },
@@ -651,7 +673,12 @@ BHC.staticEta = {
             type: "function",
             target: "allPlayer",
             onTrigger(index, slot, target, magnitude) {
-                bulletHell({"bouncingDiamond": {diamondCount: 5+magnitude, enemySpeed: 3}}, {width: 700, height: 700, duration: 31-magnitude, timed: true, cellSize: 50, start: "cell", goal: "cell"})
+                let random = Math.random()
+                if (random < 0.5) {
+                    bulletHell({"bouncingDiamond": {diamondCount: 5+magnitude, enemySpeed: 3}}, {width: 600, height: 600, duration: 62-(magnitude*2), timed: true, cellSize: 50, start: "cell", goal: "cell"})
+                } else {
+                    bulletHell({"diamondAttack": {diamondAmount: 1, bulletRadius: 8, enemySpeed: 3+(magnitude/5), intervalDiv: 0.75+(magnitude/8)}}, {width: 600, height: 600, duration: 62-(magnitude*2), timed: true, cellSize: 50, start: "cell", goal: "cell"})
+                }
             },
             cooldown: new Decimal(10),
         },
@@ -687,7 +714,12 @@ BHC.staticTheta = {
             type: "function",
             target: "allPlayer",
             onTrigger(index, slot, target, magnitude) {
-                bulletHell({"centerSpiralAttack": {spiralAngle: 0, spiralRate: 0.65, spiralInterval: 55-(magnitude*5), radialStart: 0, bulletSpeed: 4, spiralBullets: true}, "centerSingleAttack": {bulletSpeed: 6, shootInterval: 800-(magnitude*50)}}, {start: "left", height: 700, duration: 7+magnitude})
+                let random = Math.random()
+                if (random < 0.5) {
+                    bulletHell({"centerSpiralAttack": {spiralAngle: 0, spiralRate: 0.65, spiralInterval: 55-(magnitude*5), radialStart: 0, bulletSpeed: 4, spiralBullets: true}, "centerSingleAttack": {bulletSpeed: 6, shootInterval: 650-(magnitude*50), bulletRadius: 20}}, {start: "left", height: 700, duration: 7+magnitude})
+                } else {
+                    bulletHell({"centerSpiralAttack": {spiralAngle: 0, spiralRate: 0.65, spiralInterval: 55-(magnitude*5), radialStart: 0, bulletSpeed: 4, spiralBullets: true}, "centerSpreadAttack": {bulletSpeed: 6, spreadInterval: 1000-(magnitude*100), spreadCount: 4, spreadAngle: Math.PI/3}}, {start: "left", height: 700, duration: 7+magnitude})
+                }
             },
             cooldown: new Decimal(6),
         },
@@ -741,7 +773,12 @@ BHC.staticIota = {
             type: "function",
             target: "allPlayer",
             onTrigger(index, slot, target, magnitude) {
-                bulletHell({"bombAttack": {bombsPerSecond: 1+(magnitude/8), bombFallSpeed: 4, miniBombCount: 2, miniBombSpeed: 2, miniBombDelay: 600, bulletCount: 8, bulletSpeed: 2}}, {duration: 7+magnitude})
+                let random = Math.random()
+                if (random < 0.5) {
+                    bulletHell({"bombAttack": {bombsPerSecond: 1+(magnitude/8), bombFallSpeed: 4, miniBombCount: 2, miniBombSpeed: 2, miniBombDelay: 600, bulletCount: 8, bulletSpeed: 2}}, {duration: 7+magnitude})
+                } else {
+                    bulletHell({"bombAttack": {bombsPerSecond: 0.5+(magnitude/10), bombFallSpeed: 4, miniBombCount: 3, miniBombSpeed: 5, miniBombDelay: 600, bulletCount: 5, bulletSpeed: 3}, "bulletRain": {bulletPerSec: 4+magnitude}}, {duration: 7+magnitude})
+                }
             },
             cooldown: new Decimal(12),
         },
@@ -952,7 +989,7 @@ BHC.staticHekaton = {
             onTrigger(index, slot, target, magnitude) {
                 let random = Math.random()
                 if (random < 0.33) {
-                    bulletHell({"centerIcon": {locX: 600, locY: 250, radius: 64, fillColor: "#0091DC", strokeColor: "#094394", symbol: "⧖"}, "centerSpiralAttack": {locX: 600, locY: 250, spiralAngle: 0, spiralRate: 0.65, spiralInterval: 26-(magnitude*2), radialStart: 64, bulletSpeed: 6, spiralBullets: true}}, {duration: 10+(magnitude*2)})
+                    bulletHell({"centerIcon": {locX: 600, locY: 250, radius: 64, fillColor: "#0091DC", strokeColor: "#094394", symbol: "⧖"}, "centerSpiralAttack": {locX: 600, locY: 250, spiralAngle: 0, spiralRate: 0.65, spiralInterval: 22-(magnitude*2), radialStart: 64, bulletSpeed: 6, spiralBullets: true}}, {duration: 10+(magnitude*2)})
                 } else if (random < 0.66) {
                     bulletHell({"chargingIcon": {locX: 600, locY: 250, radius: 64, fillColor: "#0091DC", strokeColor: "#094394", symbol: "⧖", enemySpeed: 5, burstBullets: 3, burstViolence: 0.5, lungeTimer: 0, lungeCooldown: 0, lastTick: false}}, {duration: 10+(magnitude*2)})
                 } else {
@@ -981,7 +1018,7 @@ BHC.staticHekaton = {
             name: "Blood Buzz",
             passive: true,
             constantType: "effect",
-            target: "celestialite",
+            constantTarget: "celestialite",
             properties: {
                 "agilityAdd"() {return Decimal.sub(1, player.bh.celestialite.health.div(player.bh.celestialite.maxHealth)).mul(150)},
             },

--- a/js/Cantepocalypse/oil.js
+++ b/js/Cantepocalypse/oil.js
@@ -73,6 +73,9 @@
         // POWER MODIFIERS
         if (!inChallenge("fu", 12)) player.oi.oilToGet = player.oi.oilToGet.pow(levelableEffect("pet", 405)[1])
 
+        // SOFTCAP
+        if (player.oi.oilToGet.gte("1e10000")) player.oi.oilToGet = player.oi.oilToGet.div("1e10000").pow(0.2).mul("1e10000")
+
         if (!inChallenge("fu", 11) && !inChallenge("fu", 12)) player.oi.oil = player.oi.oil.add(player.oi.oilToGet.mul(Decimal.mul(buyableEffect("fa", 204), delta)))
 
         player.oi.oilEffect = player.oi.oil.pow(0.65).div(1.5).add(1)
@@ -625,6 +628,7 @@
                             player.oi.oilToGet.gte(1) ? look.color = "white" : look.color = "gray"
                             return look
                         }],
+                        ['raw-html', () => {return player.oi.oilToGet.gte("1e10000") ? "<small style='margin-left:8px'>[SOFTCAPPED]</small>" : ""}, {color: "red", fontSize: "20px", fontFamily: "monospace"}]
                     ]],
                     ["raw-html", () => {return "Boosts repli-trees and extends repli-tree softcap by x" + format(player.oi.oilEffect)}, {color: "white", fontSize: "16px", fontFamily: "monospace"}],
                     ["blank", "25px"],

--- a/js/Check Back/gwaTemple.js
+++ b/js/Check Back/gwaTemple.js
@@ -162,7 +162,7 @@ addLayer("gwaTemple", {
             if (hasUpgrade("gwaTemple", 25)) mult = new Decimal(25)
             if (hasUpgrade("gwaTemple", 7) && Math.random() < chance) gain = gain.mul(mult)
             player.gwaTemple.gwaPoints = player.gwaTemple.gwaPoints.add(gain)
-            if (player.tab == "gwaTemple") makeParticles(BIG_COOKIE_NUMBER, 1, `normal`, {x: mouseX-80+(Math.random()*10), text: "+" + formatSimple(gain), style: {color: "#ffb"}})
+            if (player.tab == "gwaTemple" && gain.gt(0)) makeParticles(BIG_COOKIE_NUMBER, 1, `normal`, {x: mouseX-80+(Math.random()*10), text: "+" + formatSimple(gain), style: {color: "#ffb"}})
         }
     },
     clickables: {
@@ -1143,7 +1143,7 @@ addLayer("gwaTemple", {
     tabFormat: [
         ["row", [
             ["raw-html", () => { return "You have <h3>" + format(player.gwaTemple.gwaPoints) + "</h3> gwa points" }, {color: "#ffb", fontSize: "24px", fontFamily: "monospace" }],
-            ["raw-html", () => { return "(+" + format(player.gwaTemple.gwaPointsGain) + ")"}, {color: "#ffb", fontSize: "24px", fontFamily: "monospace", marginLeft: "10px"}],
+            ["raw-html", () => { return player.gwaTemple.gwaPointsGain.gt(0) ? "(+" + format(player.gwaTemple.gwaPointsGain) + ")" : ""}, {color: "#ffb", fontSize: "24px", fontFamily: "monospace", marginLeft: "10px"}],
         ]],
         ["raw-html", () => {return hasUpgrade("gwaTemple", 5) ? "Boosts gwa pet effects by ^" + formatSimple(player.gwaTemple.gwaPointsEffect, 3) : ""}, {color: "#ffb", fontSize: "20px", fontFamily: "monospace"}],
         ["raw-html", () => { return player.gwaTemple.gwaPoints.gte(1e100) ? "UNAVOIDABLE SOFTCAP: Gain past 1e100 is raised by ^" + formatShortSimple(player.gwaTemple.firstSoftcap, 3) : ""}, {color: "red", fontSize: "16px", fontFamily: "monospace"}],

--- a/js/Check Back/pet.js
+++ b/js/Check Back/pet.js
@@ -731,7 +731,7 @@ addLayer("pet", {
         let abilityTimeDecrease = new Decimal(1)
         abilityTimeDecrease = abilityTimeDecrease.mul(player.dv.timeDrainRate)
         if (getLevelableTier("pu", 303, true)) abilityTimeDecrease = abilityTimeDecrease.div(levelableEffect("pu", 303)[0])
-        if (hasMilestone("dgj", 16)) abilityTimeDecrease = abilityTimeDecrease.mul(player.dgj.milestone3Effect)
+        if (hasMilestone("dgj", 16)) abilityTimeDecrease = abilityTimeDecrease.div(player.dgj.milestone3Effect)
         player.pet.legPetTimers[0].current = player.pet.legPetTimers[0].current.sub(abilityTimeDecrease.mul(delta))
 
         player.pet.legPetTimers[1].current = player.pet.legPetTimers[1].current.sub(delta)

--- a/js/DarkU1/normality.js
+++ b/js/DarkU1/normality.js
@@ -291,7 +291,7 @@
             currency() { return player.dn.normality},
             pay(amt) { player.dn.normality = this.currency().sub(amt) },
             effect(x) { return getBuyableAmount(this.layer, this.id).mul(0.1).add(1) },
-            unlocked() { return getLevelableTier("pu", 209, true) },
+            unlocked() { return getLevelableTier("pu", 210, true) },
             cost(x) { return this.costGrowth().pow(x || getBuyableAmount(this.layer, this.id)).mul(this.costBase()) },
             canAfford() { return this.currency().gte(this.cost()) },
             title() {

--- a/js/DarkU1/punchcards.js
+++ b/js/DarkU1/punchcards.js
@@ -1469,7 +1469,7 @@ addLayer("pu", {
                     "Unlock a new normality buyable<br>",
                     !getLevelableTier(this.layer, this.id, true) ? "</span>" : "",
                     "<u>Passive</u><br>",
-                    "x" + format(this.effect()[1]) + " to hex power",
+                    "^" + format(this.effect()[1]) + " to hex power",
                     getLevelableAmount(this.layer, this.id).gte(10) ? "<br><div style='font-size:10px;color:red'>[EFFECTS SOFTCAPPED]</div>" : "",
                 ]
                 return str.join("")
@@ -1484,8 +1484,8 @@ addLayer("pu", {
             effect() {
                 let eff = [new Decimal(1), new Decimal(1)]
                 eff[0] = player.dn.normality.pow(0.11).mul(100).add(1).pow(this.effectScale()).pow(player.bl.bloodEffect)
-                if (getLevelableAmount(this.layer, this.id).lt(10)) eff[1] = getLevelableAmount(this.layer, this.id).add(1).pow(1.4)
-                if (getLevelableAmount(this.layer, this.id).gte(10)) eff[1] = getLevelableAmount(this.layer, this.id).add(1).sub(9).pow(1.2).mul(28.70)
+                if (getLevelableAmount(this.layer, this.id).lt(10)) eff[1] = getLevelableAmount(this.layer, this.id).div(100).add(1)
+                if (getLevelableAmount(this.layer, this.id).gte(10)) eff[1] = getLevelableAmount(this.layer, this.id).div(500).add(1.08)
                 return eff
             },
             // CLICK CODE

--- a/js/Hex/power.js
+++ b/js/Hex/power.js
@@ -25,12 +25,12 @@ addLayer("hpw", {
         if (hasUpgrade("cs", 202)) player.hpw.powerGain = player.hpw.powerGain.mul(2)
         player.hpw.powerGain = player.hpw.powerGain.mul(levelableEffect("pu", 203)[2])
         player.hpw.powerGain = player.hpw.powerGain.mul(levelableEffect("pet", 1106)[1])
-        player.hpw.powerGain = player.hpw.powerGain.mul(levelableEffect("pu", 210)[1])
         player.hpw.powerGain = player.hpw.powerGain.mul(buyableEffect("sme", 144))
         player.hpw.powerGain = player.hpw.powerGain.mul(buyableEffect("al", 206))
         if (player.alephsChamber.milestone[25] > 0) player.hpw.powerGain = player.hpw.powerGain.mul(36)
 
         // POWER MODIFIERS
+        player.hpw.powerGain = player.hpw.powerGain.pow(levelableEffect("pu", 210)[1])
         player.hpw.powerGain = player.hpw.powerGain.pow(player.n.pylonPassiveEffect)
 
         player.hpw.powerGain = player.hpw.powerGain.floor() // To keep power to whole numbers
@@ -1155,8 +1155,8 @@ addLayer("hpw", {
             style: {width: "120px", height: "120px", color: "rgba(0,0,0,0.8)", border: "3px solid rgba(0,0,0,0.5)", borderRadius: "15px", margin: "10px"},
         },
         7: {
-            costBase() { return new Decimal(1e60) },
-            costGrowth() { return new Decimal(1e6) },
+            costBase() { return new Decimal(1e49) },
+            costGrowth() { return new Decimal(1e7) },
             purchaseLimit() { return new Decimal(1) },
             currency() { return player.hpw.power},
             effect(x) { return getBuyableAmount(this.layer, this.id) },

--- a/js/Infinity/tavDomain.js
+++ b/js/Infinity/tavDomain.js
@@ -482,6 +482,7 @@ addLayer("tad", {
         player.tad.altInfinities.infected.effect2 = amt7.add(1).log(10).div(20).add(1)
 
         player.tad.altInfinities.infested.effect1 = amt8.add(1).log(10).div(2).add(1).pow(2)
+        if (player.tad.altInfinities.infested.effect1.gt(100)) player.tad.altInfinities.infested.effect1 = player.tad.altInfinities.infested.effect1.div(100).pow(0.2).mul(100)
         player.tad.altInfinities.infested.effect2 = amt8.add(1).log(10).div(10).add(1)
 
         // HIGHEST ALTERNATE INFINITIES AND MILESTONES
@@ -572,9 +573,16 @@ addLayer("tad", {
         },
         6: {
             title: "x10",
-            canClick() {return player.tad.highestCap.mul(10).gte(player.tad.domainCap.mul(10))},
+            canClick() {
+                if (player.alephsChamber.milestone[25] > 0) return player.tad.highestCap.mul(1e5).gte(player.tad.domainCap.mul(10))
+                return player.tad.highestCap.mul(10).gte(player.tad.domainCap.mul(10))
+            },
             unlocked: true,
-            tooltip() {return !this.canClick() ? "Need to beat " + formatWhole(player.tad.highestCap.mul(10)) + " cap first!" : ""},
+            tooltip() {
+                if (this.canClick()) return ""
+                if (player.alephsChamber.milestone[25] > 0) return "Need to beat " + formatWhole(player.tad.highestCap.mul(1e5)) + " cap first!"
+                return "Need to beat " + formatWhole(player.tad.highestCap.mul(10)) + " cap first!"
+            },
             onClick() {
                 player.tad.domainCap = player.tad.domainCap.mul(10).floor()
                 layers.tad.domainReset(10)
@@ -589,9 +597,16 @@ addLayer("tad", {
         },
         7: {
             title: "x1e5",
-            canClick() {return player.tad.highestCap.mul(10).gte(player.tad.domainCap.mul(1e5))},
+            canClick() {
+                if (player.alephsChamber.milestone[25] > 0) return player.tad.highestCap.mul(1e5).gte(player.tad.domainCap.mul(1e5))
+                return player.tad.highestCap.mul(10).gte(player.tad.domainCap.mul(1e5))
+            },
             unlocked: true,
-            tooltip() {return !this.canClick() ? "Need to beat " + formatWhole(player.tad.highestCap.mul(10)) + " cap first!" : ""},
+            tooltip() {
+                if (this.canClick()) return ""
+                if (player.alephsChamber.milestone[25] > 0) return "Need to beat " + formatWhole(player.tad.highestCap.mul(1e9)) + " cap first!"
+                return "Need to beat " + formatWhole(player.tad.highestCap.mul(1e5)) + " cap first!"
+            },
             onClick() {
                 player.tad.domainCap = player.tad.domainCap.mul(1e5).floor()
                 layers.tad.domainReset(10)
@@ -606,9 +621,16 @@ addLayer("tad", {
         },
         8: {
             title: "x1e25",
-            canClick() {return player.tad.highestCap.mul(10).gte(player.tad.domainCap.mul(1e25))},
+            canClick() {
+                if (player.alephsChamber.milestone[25] > 0) return player.tad.highestCap.mul(1e5).gte(player.tad.domainCap.mul(1e25))
+                return player.tad.highestCap.mul(10).gte(player.tad.domainCap.mul(1e25))
+            },
             unlocked: true,
-            tooltip() {return !this.canClick() ? "Need to beat " + formatWhole(player.tad.highestCap.mul(10)) + " cap first!" : ""},
+            tooltip() {
+                if (this.canClick()) return ""
+                if (player.alephsChamber.milestone[25] > 0) return "Need to beat " + formatWhole(player.tad.highestCap.mul(1e29)) + " cap first!"
+                return "Need to beat " + formatWhole(player.tad.highestCap.mul(1e25)) + " cap first!"
+            },
             onClick() {
                 player.tad.domainCap = player.tad.domainCap.mul(1e25).floor()
                 layers.tad.domainReset(10)

--- a/js/Singularity/coreScraps.js
+++ b/js/Singularity/coreScraps.js
@@ -831,13 +831,13 @@
             title: "CS Degree",
             unlocked() {return hasUpgrade("depth4", 5)},
             canAfford() {return hasUpgrade("depth4", 5)},
-            description: "Lines of code raise mod requirement.",
+            description: "Code experience raise mod requirement.",
             cost: new Decimal(1e21),
             currencyLocation() { return player.cs.scraps.code },
             currencyDisplayName: "Code Core Scraps",
             currencyInternalName: "amount",
             effect() {
-                return Decimal.div(1, player.m.linesOfCode.add(1).log("1e1000000").div(10).add(1))
+                return Decimal.div(1, player.m.codeExperience.add(1).log("1e1500000").add(1))
             },
             effectDisplay() { return "^"+format(upgradeEffect(this.layer, this.id), 4) }, // Add formatting to the effect
             style() {

--- a/js/Singularity/starmetalAlloy.js
+++ b/js/Singularity/starmetalAlloy.js
@@ -34,6 +34,9 @@
     color: "#d460eb",
     update(delta) {
         let onepersec = new Decimal(1)
+
+        if (options.fullscreen && player.tab == "sma") options.fullscreen = false
+        
         // Set Autocrunch Values
         if (player.sma.input.gte(1) && !player.sma.type) player.sma.amount = player.sma.input
         if (player.sma.input.lt(1) && !player.sma.type) player.sma.amount = new Decimal(1)

--- a/js/Zar/wheelOfFortune.js
+++ b/js/Zar/wheelOfFortune.js
@@ -19,7 +19,7 @@
 
         currentlySelectedSegment: -1,
 
-        segmentGains: [new Decimal(0), new Decimal(0), new Decimal(0), new Decimal(0), new Decimal(0), new Decimal(0), new Decimal(0), new Decimal(0)],
+        segmentGains: [new Decimal(1), new Decimal(1), new Decimal(1), new Decimal(1), new Decimal(1), new Decimal(1), new Decimal(1), new Decimal(1)],
 
         wheelPoints: new Decimal(0),
         wheelPointsEffect: new Decimal(1),

--- a/js/cutscene.js
+++ b/js/cutscene.js
@@ -3259,6 +3259,7 @@
             portrait: "resources/secret.png",
             music: "music/alephCutscene.mp3",
             trigger() {return player.bh.currentStage == "alephsChamber" && Decimal.eq(player.bh.combo, 24)},
+            onStart() {player.bh.bhPause = true},
             dialogue: [
                 { text: "After a barrage of bee-like celestialites, you finally approach Aleph."},
                 { text: "After all this time, you get to see how she looks up close."},
@@ -3271,6 +3272,7 @@
                 { text: "Aleph comes in for a strike."},
                 { text: "It's about time..."},
             ],
+            onEnd() {player.bh.bhPause = false},
         },
         "Hive-Chamber-Fight-Mid1": {
             type: "normal",

--- a/js/cutscene.js
+++ b/js/cutscene.js
@@ -2220,6 +2220,7 @@
             portrait: "resources/secret.png",
             music: "music/matosCutscene.mp3",
             trigger() {return player.bh.currentStage == "matosLair" && player.bh.combo == 24},
+            onStart() {player.bh.bhPause = true},
             dialogue: [
                 { text: "As the last of Matos' minions are slain, a light emanates from the deepest depths of the hole." },
                 { text: "Matos' form appears from the light. A metallic being made out of red-glowing rusted metal and steel." },
@@ -2240,6 +2241,7 @@
                 { text: "I have been waiting thousands of years for this very moment.", portrait: "resources/matos.png"  },
                 { text: "Our battle will begin.", portrait: "resources/matos.png"  },
             ],
+            onEnd() {player.bh.bhPause = false},
         },
         "BH-Matos-End": {
             type: "normal",
@@ -3278,7 +3280,7 @@
             type: "normal",
             background: "#cccccc",
             portrait: "resources/secret.png",
-            trigger() {return player.bh.currentStage == "alephsChamber" && Decimal.eq(player.bh.combo, 24) && player.bh.celestialite.actions[3].variables.attacks && player.bh.celestialite.actions[3].variables.attacks == 1},
+            trigger() {return player.bh.currentStage == "alephsChamber" && Decimal.eq(player.bh.combo, 24) && player.bh.celestialite.health.lte(6000)},
             onStart() {player.bh.bhPause = true},
             dialogue: [
                 { text: "You are brought into a flashback."},
@@ -3317,7 +3319,7 @@
             type: "normal",
             background: "#cccccc",
             portrait: "resources/secret.png",
-            trigger() {return player.bh.currentStage == "alephsChamber" && Decimal.eq(player.bh.combo, 24) && player.bh.celestialite.actions[3].variables.attacks && player.bh.celestialite.actions[3].variables.attacks == 3},
+            trigger() {return player.bh.currentStage == "alephsChamber" && Decimal.eq(player.bh.combo, 24) && player.bh.celestialite.health.lte(3000)},
             onStart() {player.bh.bhPause = true},
             dialogue: [
                 { text: "I've had a glimpse of your past, Aleph.", portrait: "resources/player.png"},

--- a/js/layers.js
+++ b/js/layers.js
@@ -238,9 +238,9 @@
 
         player.i.pylonEnergyEffect = player.i.pylonEnergy.pow(4).add(1).pow(player.i.pylonTierEffect)
         player.i.pylonEnergyEffect2 = player.i.pylonEnergy.pow(0.15).add(1).pow(player.i.pylonTierEffect)
-        if (player.i.pylonEnergyEffect2.gt(10000)) player.i.pylonEnergyEffect2 = player.i.pylonEnergyEffect2.div(10000).pow(0.5).mul(10000)
+        if (player.i.pylonEnergyEffect2.gt(10000)) player.i.pylonEnergyEffect2 = player.i.pylonEnergyEffect2.div(10000).pow(0.1).mul(10000)
         player.i.pylonEnergyEffect3 = player.i.pylonEnergy.pow(0.1).add(1).pow(player.i.pylonTierEffect)
-        if (player.i.pylonEnergyEffect3.gt(1000)) player.i.pylonEnergyEffect3 = player.i.pylonEnergyEffect3.div(1000).pow(0.5).mul(1000)
+        if (player.i.pylonEnergyEffect3.gt(1000)) player.i.pylonEnergyEffect3 = player.i.pylonEnergyEffect3.div(1000).pow(0.1).mul(1000)
 
         player.i.pylonTierEffect = player.i.pylonTier.sub(1).pow(0.3).div(10).add(1)
 

--- a/js/mod.js
+++ b/js/mod.js
@@ -844,6 +844,7 @@ let changelog = `<h1>Changelog:</h1><br>
 			- Made the ancient pylon effect softcap notably stronger.<br>
 			- Nerfed moonstone's effect on rocket part gain.<br>
 			- Buffed the base formula for stars.<br>
+			- Decreased the star softcap exponent by -0.1. (Due to fixing the softcap start)<br>
 			- Nerfed the first space building.<br><br>
 		Bugfixes:<br>
 			- Fixed space battle boss-fights crashing the game.<br>
@@ -861,7 +862,8 @@ let changelog = `<h1>Changelog:</h1><br>
 			- Fixed some black heart boss cutscenes not pausing black heart.<br>
 			- Fixed the aleph fight cutscenes having the wrong requirement code.<br>
 			- Fixed nest layer not changing your music.<br>
-			- Fixed some black heart character data not being reset properly.<br><br>
+			- Fixed some black heart character data not being reset properly.<br>
+			- Fixed the star softcap start not working properly.<br><br>
 	<h3>v1.12 - Aleph Update Pt II: Nested Metal</h3><br>
 		Content:<br>
 			- Remade Black Heart.<br>

--- a/js/mod.js
+++ b/js/mod.js
@@ -816,6 +816,7 @@ let changelog = `<h1>Changelog:</h1><br>
 		Content:<br>
 			- New attacks for most stagnant synestia celestialites.<br><br>
 		Minor Changes:<br>
+			- Made Gwa Point gain not show if equal to 0.<br>
 			- Aleph has a new perk that improves Tav's Domain Expansion cap increases.<br>
 			- Made \"Iridian Boost\" in Stagnant Synestia specify that it ignores softcaps.<br>
 			- Improved the text describing Stagnant Synestia's milestone effect.<br>

--- a/js/mod.js
+++ b/js/mod.js
@@ -831,14 +831,20 @@ let changelog = `<h1>Changelog:</h1><br>
 			- Reduced Cante's antimatter requirement.<br>
 			- Reduced late game marcel upgrade costs.<br>
 			- Buffed Geroa's orbital cannon skill.<br>
-			- Nerfed M-03's regen from 10/s->5/s.<br>
+			- Nerfed M-03's regen from 10/s->6/s.<br>
+			- Buffed Matos' damage from 6->10.<br>
 			- Increased timers for bullet hell maze attacks.<br>
+			- Black heart shields now decay at 1 every 20s.<br>
+			- Shield related skills were buffed to match the previous change.<br>
 			- Replaced generator based on normality's passive effect. (It is practically a buff)<br>
 			- Decreased the cost of the hex teaser.<br>
 			<i>(This changes nothing, you can't buy it even if you reach the cost)</i><br>
 			- Added a softcap to oil gain at 1e10,000.<br>
 			- Added a softcap to infested infinities effect 1. (at /100)<br>
-			- Made the ancient pylon effect softcap notably stronger.<br><br>
+			- Made the ancient pylon effect softcap notably stronger.<br>
+			- Nerfed moonstone's effect on rocket part gain.<br>
+			- Buffed the base formula for stars.<br>
+			- Nerfed the first space building.<br><br>
 		Bugfixes:<br>
 			- Fixed space battle boss-fights crashing the game.<br>
 			- Fixed instant cutscene text option skipping the first dialogue.<br>
@@ -852,7 +858,8 @@ let changelog = `<h1>Changelog:</h1><br>
 			- Fixed Celestialite Static Hekaton crashing the game.<br>
 			- Fixed grass jump milestone 6 dividing eclipse tickspeed instead of multiplying.<br>
 			- Fixed generator based on normality punchcard not unlocking its relevant normality buyable.<br>
-			- Fixed the first aleph fight cutscene not pausing black heart.<br>
+			- Fixed some black heart boss cutscenes not pausing black heart.<br>
+			- Fixed the aleph fight cutscenes having the wrong requirement code.<br>
 			- Fixed nest layer not changing your music.<br>
 			- Fixed some black heart character data not being reset properly.<br><br>
 	<h3>v1.12 - Aleph Update Pt II: Nested Metal</h3><br>

--- a/js/mod.js
+++ b/js/mod.js
@@ -811,8 +811,8 @@ let credits = `<h1>Credits:</h1><br>
 		`
 
 let changelog = `<h1>Changelog:</h1><br>
-	<h3>v1.12.1 - Bugfixes (and beefixes)</h3><br>
-	<i>[This contains all fixes since v1.12]</i><br>
+	<h3>v1.12.1 - Bugfixes <small>(and beefixes)</small></h3><br>
+	<small><i>[This contains all fixes since v1.12]</i></small><br>
 		Content:<br>
 			- New attacks for most stagnant synestia celestialites.<br><br>
 		Minor Changes:<br>

--- a/js/mod.js
+++ b/js/mod.js
@@ -853,7 +853,8 @@ let changelog = `<h1>Changelog:</h1><br>
 			- Fixed grass jump milestone 6 dividing eclipse tickspeed instead of multiplying.<br>
 			- Fixed generator based on normality punchcard not unlocking its relevant normality buyable.<br>
 			- Fixed the first aleph fight cutscene not pausing black heart.<br>
-			- Fixed nest layer not changing your music.<br><br>
+			- Fixed nest layer not changing your music.<br>
+			- Fixed some black heart character data not being reset properly.<br><br>
 	<h3>v1.12 - Aleph Update Pt II: Nested Metal</h3><br>
 		Content:<br>
 			- Remade Black Heart.<br>

--- a/js/mod.js
+++ b/js/mod.js
@@ -811,6 +811,48 @@ let credits = `<h1>Credits:</h1><br>
 		`
 
 let changelog = `<h1>Changelog:</h1><br>
+	<h3>v1.12.1 - Bugfixes (and beefixes)</h3><br>
+	<i>[This contains all fixes since v1.12]</i><br>
+		Content:<br>
+			- New attacks for most stagnant synestia celestialites.<br><br>
+		Minor Changes:<br>
+			- Aleph has a new perk that improves Tav's Domain Expansion cap increases.<br>
+			- Made \"Iridian Boost\" in Stagnant Synestia specify that it ignores softcaps.<br>
+			- Improved the text describing Stagnant Synestia's milestone effect.<br>
+			- Improved the text describing how to unlock the midnight theme.<br>
+			- Added a safety check in case Aleph doesn't do their final attack at -500 HP.<br>
+			- Added Aleph's celestial hall text.<br><br>
+		Balancing:<br>
+			- Heal spell no longer targets full health allies.<br>
+			- Added softcaps to gwa temple currencies.<br>
+			- Nerfed rebound celestialites.<br>
+			- Reduced time to trigger dice space easter egg.<br>
+			- Reduced Cante's antimatter requirement.<br>
+			- Reduced late game marcel upgrade costs.<br>
+			- Buffed Geroa's orbital cannon skill.<br>
+			- Nerfed M-03's regen from 10/s->5/s.<br>
+			- Increased timers for bullet hell maze attacks.<br>
+			- Replaced generator based on normality's passive effect. (It is practically a buff)<br>
+			- Decreased the cost of the hex teaser.<br>
+			<i>(This changes nothing, you can't buy it even if you reach the cost)</i><br>
+			- Added a softcap to oil gain at 1e10,000.<br>
+			- Added a softcap to infested infinities effect 1. (at /100)<br>
+			- Made the ancient pylon effect softcap notably stronger.<br><br>
+		Bugfixes:<br>
+			- Fixed space battle boss-fights crashing the game.<br>
+			- Fixed instant cutscene text option skipping the first dialogue.<br>
+			- Fixed Vespasians first skill showing up when you don't have them unlocked.<br>
+			- Fixed rebound actually making the enemy deal more damage to you <i>lmao</i>.<br>
+			- Fixed wheel of fortune being time dependent.<br>
+			- Fixed Avon not having their cutscene icon.<br>
+			- Fixed Geroa's orbital cannon skill not working.<br>
+			- Fixed black heart sometimes messing with particles.<br>
+			- Fixed MS-06 calling for the wrong currency.<br>
+			- Fixed Celestialite Static Hekaton crashing the game.<br>
+			- Fixed grass jump milestone 6 dividing eclipse tickspeed instead of multiplying.<br>
+			- Fixed generator based on normality punchcard not unlocking its relevant normality buyable.<br>
+			- Fixed the first aleph fight cutscene not pausing black heart.<br>
+			- Fixed nest layer not changing your music.<br><br>
 	<h3>v1.12 - Aleph Update Pt II: Nested Metal</h3><br>
 		Content:<br>
 			- Remade Black Heart.<br>

--- a/js/mod.js
+++ b/js/mod.js
@@ -85,6 +85,12 @@ function updateStyles() {
 		}
 	}
 
+	// ===------   PREVENT STYLING THE PARTICLE CONTAINER   ------=== //
+	const particleCont = document.getElementById('particleHolder')
+	if (particleCont && particleCont.hasAttribute('style')) {
+		particleCont.removeAttribute('style');
+	}
+
 	// ===------   Universe Bar Horizontal Scrolling   ------=== //
 	let scrollContainer = document.querySelector('.uniHolder')
 	if (scrollContainer) {
@@ -673,7 +679,7 @@ function updateStyles() {
 			player.musuniverse = "MI"
 			break;
 		case "bee": case "fl": case "bpl": case "ne": case "bb":
-		case "ho": case "wa": case "al":
+		case "ho": case "wa": case "al": case "n":
 			player.musuniverse = "UB"
 			break;
 		case "cb": case "ev0": case "ev1": case "ev2": case "ev4":
@@ -1939,6 +1945,7 @@ function fixOldSave(oldVersion){
 		}
 	}
 	if (oldVersion < 190.2) {
+		if (player.tab == "ba") player.tab = "i"
 		// Matos Variables
 		if (player.ma.matosDefeated) player.matosLair.milestone[25] = 1
 		if (player.ma.matosUnlock) {

--- a/js/rockets.js
+++ b/js/rockets.js
@@ -95,11 +95,11 @@
         if (getBuyableAmount("st", 204).gt(0)) player.ro.activatedFuel = player.ro.activatedFuel.add(player.ro.activatedFuelToGet.mul(buyableEffect("st", 204).mul(delta)))
 
         player.ro.rocketPartsContributions[0] = player.gh.steel.add(1).log(10).pow(0.2)
-        if (player.st.buyables[203].lt(1)) player.ro.rocketPartsContributions[1] = player.sma.starmetalAlloy.div(300).pow(0.5)
-        if (player.st.buyables[203].gte(1)) player.ro.rocketPartsContributions[1] = player.sma.starmetalAlloy.div(300).pow(0.5).add(1)
+        if (player.st.buyables[203].lt(1)) player.ro.rocketPartsContributions[1] = player.sma.starmetalAlloy.div(50).pow(0.3)
+        if (player.st.buyables[203].gte(1)) player.ro.rocketPartsContributions[1] = player.sma.starmetalAlloy.div(50).pow(0.3).add(1)
         player.ro.rocketPartsContributions[2] = player.p.crystals.add(1).log(10).div(100)
-        if (player.st.buyables[203].lt(1)) player.ro.rocketPartsContributions[3] = player.g.moonstone.pow(0.4).div(100)
-        if (player.st.buyables[203].gte(1)) player.ro.rocketPartsContributions[3] = player.g.moonstone.pow(0.4).div(100).add(1)
+        if (player.st.buyables[203].lt(1)) player.ro.rocketPartsContributions[3] = player.g.moonstone.add(1).log(2).div(10)
+        if (player.st.buyables[203].gte(1)) player.ro.rocketPartsContributions[3] = player.g.moonstone.add(1).log(2).div(10).add(1)
 
         player.ro.rocketPartsToGet = player.ro.rocketPartsContributions[0].mul(player.ro.rocketPartsContributions[1]).mul(player.ro.rocketPartsContributions[2]).mul(player.ro.rocketPartsContributions[3]).floor()
         player.ro.rocketPartsToGet = player.ro.rocketPartsToGet.mul(levelableEffect("pet", 501)[1]).floor()
@@ -383,7 +383,7 @@
         },
         16: {
             title() { return "<h2>Upgrade" },
-            canClick() { return player.cb.evolutionShards.gte('70') && player.cb.paragonShards.gte('15') && player.stagnantSynestia.temporalShard.gte(5) && player.au2.stars.gte('1e9') && player.sma.starmetalAlloy.gte('100000') 
+            canClick() { return player.cb.evolutionShards.gte('70') && player.cb.paragonShards.gte('15') && player.stagnantSynestia.temporalShard.gte(5) && player.au2.stars.gte('1e8') && player.sma.starmetalAlloy.gte('100000') 
                 && player.cof.coreFragments[0].gte('50') && player.cof.coreFragments[1].gte('50') && player.cof.coreFragments[2].gte('50') && player.cof.coreFragments[3].gte('50') && player.cof.coreFragments[4].gte('50')
                 && player.cof.coreFragments[5].gte('50') && player.cof.coreFragments[6].gte('50')
             },
@@ -393,7 +393,7 @@
                 player.cb.paragonShards = player.cb.paragonShards.sub(15)
                 player.stagnantSynestia.temporalShard = player.stagnantSynestia.temporalShard.sub(5)
 
-                player.au2.stars = player.au2.stars.sub(1e9)
+                player.au2.stars = player.au2.stars.sub(1e8)
                 player.sma.starmetalAlloy = player.sma.starmetalAlloy.sub(100000)
 
                 for (let i = 0; i < 7; i++)
@@ -1000,7 +1000,7 @@
                     ["raw-html", function () { return "Evolution Shards: " + formatWhole(player.cb.evolutionShards) + "/70" }, { "color": "#d487fd", "font-size": "24px", "font-family": "monospace" }],
                     ["raw-html", function () { return "Paragon Shards: " + formatWhole(player.cb.paragonShards) + "/15" }, { "color": "#4b79ff", "font-size": "24px", "font-family": "monospace" }],
                     ["raw-html", function () { return "Temporal Shards: " + formatWhole(player.stagnantSynestia.temporalShard) + "/5" }, { "color": "#77b0ffff", "font-size": "24px", "font-family": "monospace" }],
-                    ["raw-html", function () { return "Stars: " + format(player.au2.stars) + "/1e9" }, { "color": "#ffffff", "font-size": "24px", "font-family": "monospace" }],
+                    ["raw-html", function () { return "Stars: " + format(player.au2.stars) + "/1e8" }, { "color": "#ffffff", "font-size": "24px", "font-family": "monospace" }],
                     ["raw-html", function () { return "Starmetal Alloy: " + format(player.sma.starmetalAlloy) + "/100,000" }, { "color": "#ffffff", "font-size": "24px", "font-family": "monospace" }],
                     ["raw-html", function () { return "50 of every core fragment type." }, { "color": "#ffffff", "font-size": "24px", "font-family": "monospace" }],
                     ["blank", "25px"],


### PR DESCRIPTION
<h3>v1.12.1 - Bugfixes <small>(and beefixes)</small></h3>
<small><i>[This contains all fixes since v1.12]</i></small><br>
Content:<br>
			- New attacks for most stagnant synestia celestialites.<br><br>
		Minor Changes:<br>
			- Made Gwa Point gain not show if equal to 0.<br>
			- Aleph has a new perk that improves Tav's Domain Expansion cap increases.<br>
			- Made \"Iridian Boost\" in Stagnant Synestia specify that it ignores softcaps.<br>
			- Improved the text describing Stagnant Synestia's milestone effect.<br>
			- Improved the text describing how to unlock the midnight theme.<br>
			- Added a safety check in case Aleph doesn't do their final attack at -500 HP.<br>
			- Added Aleph's celestial hall text.<br><br>
		Balancing:<br>
			- Heal spell no longer targets full health allies.<br>
			- Added softcaps to gwa temple currencies.<br>
			- Nerfed rebound celestialites.<br>
			- Reduced time to trigger dice space easter egg.<br>
			- Reduced Cante's antimatter requirement.<br>
			- Reduced late game marcel upgrade costs.<br>
			- Buffed Geroa's orbital cannon skill.<br>
			- Nerfed M-03's regen from 10/s->6/s.<br>
			- Buffed Matos' damage from 6->10.<br>
			- Increased timers for bullet hell maze attacks.<br>
			- Black heart shields now decay at 1 every 20s.<br>
			- Shield related skills were buffed to match the previous change.<br>
			- Replaced generator based on normality's passive effect. (It is practically a buff)<br>
			- Decreased the cost of the hex teaser.<br>
			<i>(This changes nothing, you can't buy it even if you reach the cost)</i><br>
			- Added a softcap to oil gain at 1e10,000.<br>
			- Added a softcap to infested infinities effect 1. (at /100)<br>
			- Made the ancient pylon effect softcap notably stronger.<br>
			- Nerfed moonstone's effect on rocket part gain.<br>
			- Buffed the base formula for stars.<br>
			- Decreased the star softcap exponent by -0.1. (Due to fixing the softcap start)<br>
			- Nerfed the first space building.<br><br>
		Bugfixes:<br>
			- Fixed space battle boss-fights crashing the game.<br>
			- Fixed instant cutscene text option skipping the first dialogue.<br>
			- Fixed Vespasians first skill showing up when you don't have them unlocked.<br>
			- Fixed rebound actually making the enemy deal more damage to you <i>lmao</i>.<br>
			- Fixed wheel of fortune being time dependent.<br>
			- Fixed Avon not having their cutscene icon.<br>
			- Fixed Geroa's orbital cannon skill not working.<br>
			- Fixed black heart sometimes messing with particles.<br>
			- Fixed MS-06 calling for the wrong currency.<br>
			- Fixed Celestialite Static Hekaton crashing the game.<br>
			- Fixed grass jump milestone 6 dividing eclipse tickspeed instead of multiplying.<br>
			- Fixed generator based on normality punchcard not unlocking its relevant normality buyable.<br>
			- Fixed some black heart boss cutscenes not pausing black heart.<br>
			- Fixed the aleph fight cutscenes having the wrong requirement code.<br>
			- Fixed nest layer not changing your music.<br>
			- Fixed some black heart character data not being reset properly.<br>
			- Fixed the star softcap start not working properly.