### PR TITLE
hardcode the height of the level bar in pixels instead of relative so…

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -427,7 +427,7 @@ h1, h2, h3, b, input {
 	overflow: hidden;
 	width: 100%;
 	margin: 0%;
-	height: 100%;
+	height: 15px;
 	background-color: #0B6623;
 	transition-duration: 0.2s;
 }


### PR DESCRIPTION
… it works correctly in firefox