### PR TITLE
Boring fixes.

### DIFF
--- a/js/Black Heart/blackHeartFunctions.js
+++ b/js/Black Heart/blackHeartFunctions.js
@@ -691,7 +691,7 @@ function celestialiteReward(gain) {
         bhLog("<span style='color: #eed200'>" + str + "You gained " + formatWhole(gain.matosDust) + " matos dust! (You have " + formatWhole(player.laboratory.matosDust) + ")")
     }
     if (gain.matosShard) {
-        gain.matosDust = gain.matosShard.mul(player.laboratory.matosMult).mul(generalMult).mul(player.laboratory.matosEssence.add(1).log(10).add(1)).floor()
+        gain.matosShard = gain.matosShard.mul(player.laboratory.matosMult).mul(generalMult).mul(player.laboratory.matosEssence.add(1).log(10).add(1)).floor()
         player.laboratory.matosShard = player.laboratory.matosShard.add(gain.matosShard)
         bhLog("<span style='color: #eed200'>" + str + "You gained " + formatWhole(gain.matosShard) + " matos shards! (You have " + formatWhole(player.laboratory.matosShard) + ")")
     }

--- a/js/Black Heart/darkTemple.js
+++ b/js/Black Heart/darkTemple.js
@@ -1666,9 +1666,7 @@ addLayer("darkTemple", {
                                     if (player.darkTemple.tab == "level" && getBuyableAmount("darkTemple", player.darkTemple.selection).lt(player.darkTemple.runeCap)) {
                                         futureEffects = RUNE_EFFECTS[player.darkTemple.selection][getBuyableAmount("darkTemple", player.darkTemple.selection).add(1)]
                                         let tierMult = getBuyableAmount("darkTemple", player.darkTemple.selection+100) ? 1+(getBuyableAmount("darkTemple", player.darkTemple.selection+100).toNumber()/2) : 1
-                                        for (let i in futureEffects) {
-                                            futureEffects[i] = futureEffects[i] * tierMult
-                                        }
+                                        futureEffects = addObject({}, futureEffects, tierMult)
                                     } else if (player.darkTemple.tab == "tier" && (getBuyableAmount("darkTemple", player.darkTemple.selection+100) || player.darkTemple.tierCap).lt(player.darkTemple.tierCap)) {
                                         for (let i = 1; i < getBuyableAmount("darkTemple", player.darkTemple.selection); i++) {
                                             futureEffects = addObject(futureEffects, RUNE_EFFECTS[player.darkTemple.selection][i], 0.5)

--- a/js/Black Heart/darkTemple.js
+++ b/js/Black Heart/darkTemple.js
@@ -307,10 +307,11 @@ addLayer("darkTemple", {
         player.darkTemple.totalLevel = new Decimal(0)
         let stats = {}
         for (let j = 1; j < 6; j++) {
+            let mult = getBuyableAmount("darkTemple", j+100) ? 1+(getBuyableAmount("darkTemple", j+100).toNumber()/2) : 1
             for (let i = 1; i < getBuyableAmount("darkTemple", j).add(1); i++) {
-                stats = addObject(stats, RUNE_EFFECTS[j][i], getBuyableAmount("darkTemple", j+100) ? 1+(getBuyableAmount("darkTemple", j+100).toNumber()/2) : 1)
+                stats = addObject(stats, RUNE_EFFECTS[j][i], mult)
             }
-            player.darkTemple.totalLevel = player.darkTemple.totalLevel.add(getBuyableAmount("darkTemple", j).mul(getBuyableAmount("darkTemple", j+100) ? 1+(getBuyableAmount("darkTemple", j+100).toNumber()/2) : 1))
+            player.darkTemple.totalLevel = player.darkTemple.totalLevel.add(getBuyableAmount("darkTemple", j).mul(mult))
         }
         if (stats.sp) player.darkTemple.spAdd = new Decimal(stats.sp).floor()
         if (stats.scd) player.darkTemple.skillCost = Decimal.pow(2, stats.scd)
@@ -1817,9 +1818,9 @@ function addObject(obj1, obj2, mult = 1) {
 
     for (const key in obj2) {
         if (combined.hasOwnProperty(key)) {
-            combined[key] += obj2[key] * mult;
+            combined[key] += (obj2[key] * mult);
         } else {
-            combined[key] = obj2[key] * mult;
+            combined[key] = (obj2[key] * mult);
         }
     }
 

--- a/js/Singularity/starmetalAlloy.js
+++ b/js/Singularity/starmetalAlloy.js
@@ -34,8 +34,6 @@
     color: "#d460eb",
     update(delta) {
         let onepersec = new Decimal(1)
-
-        if (options.fullscreen && player.tab == "sma") options.fullscreen = false
         
         // Set Autocrunch Values
         if (player.sma.input.gte(1) && !player.sma.type) player.sma.amount = player.sma.input

--- a/js/mod.js
+++ b/js/mod.js
@@ -59,6 +59,14 @@ function updateStyles() {
 	if (player.tab == 'c') player.hideMenu = true
 	if (options.fullscreen) player.hideMenu = true
 
+	// ===------   PREVENT UNWANTED FULLSCREENS   ------=== //
+	if (options.fullscreen && player.tab != "bh" &&
+	!(player.tab == "ir" && player.subtabs["ir"]["stuff"] == "Battle") &&
+	!(player.tab == "bl" && player.subtabs["bl"]["stuff"] == "Battle") &&
+	!(player.tab == "cbs" && player.subtabs["cbs"]["stuff"] == "Battle")) {
+		options.fullscreen = false
+	}
+
 	// ===------   CHANGE LAYER SIZE   ------=== //
 	const LAYERHOLDER = document.getElementById('layerHolder')
 	if (LAYERHOLDER) {


### PR DESCRIPTION
* Fixes Matos Shards being uneffected by multipliers
* Improves syntax to hopefully fix the weird rune stat inflation bug that isn't replicable. 
* Made `options.fullscreen` automatically turn false if not in the tabs/subtabs that can be fullscreened