### PR TITLE
Fix for starting Cantepocalypse crash

### DIFF
--- a/js/Cantepocalypse/enhance.js
+++ b/js/Cantepocalypse/enhance.js
@@ -49,7 +49,7 @@
         for (let i = 0; i < player.en.enhancersUnlocked.length; i++) {
             player.en.enhancerXP[i] = player.en.enhancerXP[i].add(player.en.enhancerXPPerSecond[i].mul(delta))
             if (player.en.enhancerXP[i].gte(player.en.enhancerXPReq[i])) {
-                 if (player.en.enhancerXPPerSecond[i].gte(player.en.enhancerXPReq[i].mul(10))) {
+                 if (player.en.enhancerXPPerSecond[i].gte(player.en.enhancerXPReq[i].mul(10)) && player.en.enhancerXPReq[i].gt(0)) {
                 player.en.enhancerLevels[i] = player.en.enhancerLevels[i].add(player.en.enhancerXPPerSecond[i].div(player.en.enhancerXPReq[i]).mul(delta).floor())
                  }
                 player.en.enhancerLevels[i] = player.en.enhancerLevels[i].add(1) //tentative to change if bulk leveling is added

--- a/js/Cantepocalypse/enhance.js
+++ b/js/Cantepocalypse/enhance.js
@@ -20,7 +20,7 @@
         */
        enhancerXP: [new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),],
        enhancerXPPerSecond: [new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),],
-       enhancerXPReq: [new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),],
+       enhancerXPReq: [new Decimal(10), new Decimal(1000), new Decimal(25000), new Decimal(125000), new Decimal(6250000)],
        enhancersUnlocked: [true,false,false,false,false,],
 
        enhancerAllocated: [new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),],
@@ -61,8 +61,6 @@
 
         if (hasUpgrade("en", 13)) player.en.enhancersUnlocked[1] = true
         if (hasUpgrade("en", 15)) player.en.enhancersUnlocked[2] = true
-
-        player.en.enhancerXPReq = [new Decimal(10), new Decimal(1000), new Decimal(25000), new Decimal(125000), new Decimal(6250000)] //very tentative to change
 
         player.en.enhancerXPReq[0] = player.en.enhancerLevels[0].pow(0.5).add(1).mul(10)
         if (player.en.enhancerLevels[0].gt(10000)) player.en.enhancerXPReq[0] = player.en.enhancerLevels[0].pow(0.65).add(1).mul(10)


### PR DESCRIPTION
When clicking the 4th trial to start Cantepocalypse, default values of 0 for XP levels in Enhance cause a divide by zero when calculating enhancer levels which then propagates NaNs through the game state and causes a hardlock.

Moved the default XP values up into the initialization and added a div by zero check to the condition just in case, since this would still blast anyone with an old save.

Tested with the following save; will get NaN on live, and progresses normally on the fork. All values that are being changed should be overwritten in the apply immediately after so it looks like no downstream consequences, but I don't have a save up to the Enhancer layer to test that explicitly.

[Otho - Pre 4th Trial.txt](https://github.com/user-attachments/files/28809157/Otho.-.Pre.4th.Trial.txt)

(Not sure if this needs to go to the Patch fork, let me know or merge it to wherever.)