### PR TITLE
Hotfix for the crashes and inflation

### DIFF
--- a/js/AltU2/altUni2.js
+++ b/js/AltU2/altUni2.js
@@ -72,7 +72,8 @@
         player.au2.starsToGet = player.au2.starsToGet.mul(buyableEffect("stagnantSynestia", 3)).floor()
         player.au2.starsToGet = player.au2.starsToGet.mul(levelableEffect("ir", 1)[0]).floor()
         player.au2.starsToGet = player.au2.starsToGet.mul(buyableEffect("sb", 101)).floor()
-        player.au2.starsToGet = player.au2.starsToGet.mul(levelableEffect("car", 311)[0]).floor()
+
+        player.au2.starsToGet = player.au2.starsToGet.pow(levelableEffect("car", 311)[0]).floor()
     },
     clickables: {
         1: {

--- a/js/Black Heart/blackHeart.js
+++ b/js/Black Heart/blackHeart.js
@@ -836,7 +836,11 @@ addLayer("bh", {
                 player.laboratory.cooldown = player.laboratory.cooldownMax
                 player.bh.autoCooldown = Decimal.mul(player.laboratory.cooldownMax.sub(30), -1)
             }
-            BHStageEnter(player.bh.autoEnter)
+            if (player.bh.autoEnter == "zarDungeon") {
+                BHStageEnter("zarDungeon", [player.zarDungeon.navToggle ? "nav" : "none", player.zarDungeon.diceFiveToggle ? "diceFive" : "none", "none"])
+            } else {
+                BHStageEnter(player.bh.autoEnter)
+            }
         }
         if (player.bh.exitConfirm.gt(0)) player.bh.exitConfirm = player.bh.exitConfirm.sub(normTime)
 

--- a/js/Black Heart/blackHeartFunctions.js
+++ b/js/Black Heart/blackHeartFunctions.js
@@ -991,8 +991,40 @@ function bhLog(line) {
     if (player.bh.log.length > 10) player.bh.log.shift(); // Ensure log size remains consistent
 }
 
-function BHStageEnter(stage) {
+function BHStageEnter(stage, chars = false) {
     player.subtabs["bh"]["stuff"] = "battle"
+
+    if (chars) {
+        for (let c = 0; c < 3; c++) {
+            if (chars[c] == "none") {
+                if (player.bh.characters[c].id != "none") player.bh.characterData[player.bh.characters[c].id].selected = 0
+                
+                player.bh.characters[c].id = "none"
+                for (let j = 0; j < 4; j++) {
+                    player.bh.characters[c].skills[j].id = "none"
+                }
+            } else {
+                if (player.bh.characterData[chars[c]].selected) {
+                    player.bh.characterData[chars[c]].selected = 0
+                    for (let i = 0; i < 3; i++) {
+                        if (player.bh.characters[i].id == chars[c]) {
+                            player.bh.characters[i].id = "none"
+                            for (let j = 0; j < 4; j++) {
+                                player.bh.characters[i].skills[j].id = "none"
+                            }
+                        }
+                    }
+                }
+                if (player.bh.characters[c].id != "none") player.bh.characterData[player.bh.characters[c].id].selected = 0
+                player.bh.characters[c].id = chars[c]
+
+                player.bh.characterData[chars[c]].selected = c+1
+                for (let i = 0; i < 4; i++) {
+                    player.bh.characters[c].skills[i].id = player.bh.characterData[chars[c]].skills[i]
+                }
+            }
+        }
+    }
 
     for (let i = 0; i < 3; i++) {
         player.bh.characters[i].health = player.bh.characters[i].maxHealth

--- a/js/Black Heart/darkTemple.js
+++ b/js/Black Heart/darkTemple.js
@@ -1824,3 +1824,75 @@ function addObject(obj1, obj2, mult = 1) {
 
     return combined;
 }
+
+BHS.darkTemple = {
+    nameCap: "Dark Temple",
+    nameLow: "Dark Temple",
+    music: "music/confrontation.mp3",
+    comboLimit: 666,
+    comboScaling: 6,
+    comboScalingStart: 66,
+    generateCelestialite(combo) {
+        return "nac"
+    },
+}
+
+BHC.nac = {
+    name: "██████",
+    symbol: "█",
+    style: {
+        background: "radial-gradient(#116, black)",
+        color: "black",
+        borderColor: "#226",
+    },
+    health: new Decimal(666666666),
+    damage: new Decimal(666666),
+    attributes: {
+        "air": new Decimal(1), // Resistance DMG Mult
+        "warded": new Decimal(1), // Resistance DMG Mult
+        "stealthy": new Decimal(1), // Resistance DMG Mult
+        "anima": new Decimal(1), // Resistance DMG Mult
+    },
+    actions: {
+        0: {
+            name: "█████",
+            instant: true,
+            type: "damage",
+            target: "allPlayer",
+            method: "physical",
+            value: new Decimal(6),
+            cooldown: new Decimal(6),
+        },
+        1: {
+            name: "█████",
+            instant: true,
+            type: "damage",
+            target: "allPlayer",
+            method: "physical",
+            value: new Decimal(12),
+            cooldown: new Decimal(12),
+        },
+        2: {
+            name: "█████",
+            instant: true,
+            type: "damage",
+            target: "allPlayer",
+            method: "physical",
+            value: new Decimal(18),
+            cooldown: new Decimal(18),
+        },
+        3: {
+            name: "█████",
+            instant: true,
+            type: "damage",
+            target: "allPlayer",
+            method: "physical",
+            value: new Decimal(24),
+            cooldown: new Decimal(24),
+        },
+    },
+    reward() {
+        let gain = {}
+        return gain
+    },
+}

--- a/js/Black Heart/skills.js
+++ b/js/Black Heart/skills.js
@@ -118,9 +118,13 @@ BHA.general_recklessAbandon = {
         let effect = new Decimal(25).add(player.bh.skillData["general_recklessAbandon"].level.mul(5))
         if (player.alephsChamber.milestone[25] >= 2) effect = effect.mul(Decimal.div(char.potency.add(100), 100))
         if (player.bh.currentStage != "none") return "Convert 25% of your health into damage, at " + formatSimple(effect) + "% efficiency"
-        return "Convert 25% of your health into damage, at " + formatSimple(effect) + "% efficiency<br>Currently:<br>" +
-        formatSimple(player.bh.characterData[char.id].health) + " HP ⇒ " + formatSimple(player.bh.characterData[char.id].health.mul(0.75)) + " HP<br>" +
-        formatSimple(char.damage) + " DMG ⇒ " + formatSimple(char.damage.add(player.bh.characterData[char.id].health.mul(0.75).div(4).mul(effect.div(100)))) + " DMG"
+        if (player.bh.characterData[char.id]) {
+            return "Convert 25% of your health into damage, at " + formatSimple(effect) + "% efficiency<br>Currently:<br>" +
+            formatSimple(player.bh.characterData[char.id].health) + " HP ⇒ " + formatSimple(player.bh.characterData[char.id].health.mul(0.75)) + " HP<br>" +
+            formatSimple(char.damage) + " DMG ⇒ " + formatSimple(char.damage.add(player.bh.characterData[char.id].health.mul(0.75).div(4).mul(effect.div(100)))) + " DMG"
+        } else {
+            return "Convert 25% of your health into damage, at " + formatSimple(effect) + "% efficiency"
+        }
     },
     passiveText() {return "+" + formatSimple(player.bh.skillData["general_recklessAbandon"].maxLevel) + " HP"},
     char: "general",

--- a/js/Cantepocalypse/enhance.js
+++ b/js/Cantepocalypse/enhance.js
@@ -20,7 +20,7 @@
         */
        enhancerXP: [new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),],
        enhancerXPPerSecond: [new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),],
-       enhancerXPReq: [new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),],
+       enhancerXPReq: [new Decimal(10), new Decimal(1000), new Decimal(25000), new Decimal(125000), new Decimal(6250000)],
        enhancersUnlocked: [true,false,false,false,false,],
 
        enhancerAllocated: [new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),new Decimal(0),],
@@ -46,6 +46,17 @@
         if (player.en.enhancePointsToAllocate.gt(player.en.enhancePoints)) player.en.enhancePointsToAllocate = player.en.enhancePoints
 
         //enhancers
+        player.en.enhancerXPReq = [new Decimal(10), new Decimal(1000), new Decimal(25000), new Decimal(125000), new Decimal(6250000)] //very tentative to change
+
+        player.en.enhancerXPReq[0] = player.en.enhancerLevels[0].pow(0.5).add(1).mul(10)
+        if (player.en.enhancerLevels[0].gt(10000)) player.en.enhancerXPReq[0] = player.en.enhancerLevels[0].pow(0.65).add(1).mul(10)
+        
+        player.en.enhancerXPReq[1] = player.en.enhancerLevels[1].pow(0.65).add(1).mul(1000)
+        if (player.en.enhancerLevels[1].gt(10000)) player.en.enhancerXPReq[1] = player.en.enhancerLevels[1].pow(0.75).add(1).mul(1000)
+
+        player.en.enhancerXPReq[2] = player.en.enhancerLevels[2].pow(0.75).add(1).mul(25000)
+        if (player.en.enhancerLevels[2].gt(10000)) player.en.enhancerXPReq[2] = player.en.enhancerLevels[2].pow(0.85).add(1).mul(25000)
+
         for (let i = 0; i < player.en.enhancersUnlocked.length; i++) {
             player.en.enhancerXP[i] = player.en.enhancerXP[i].add(player.en.enhancerXPPerSecond[i].mul(delta))
             if (player.en.enhancerXP[i].gte(player.en.enhancerXPReq[i])) {
@@ -61,17 +72,6 @@
 
         if (hasUpgrade("en", 13)) player.en.enhancersUnlocked[1] = true
         if (hasUpgrade("en", 15)) player.en.enhancersUnlocked[2] = true
-
-        player.en.enhancerXPReq = [new Decimal(10), new Decimal(1000), new Decimal(25000), new Decimal(125000), new Decimal(6250000)] //very tentative to change
-
-        player.en.enhancerXPReq[0] = player.en.enhancerLevels[0].pow(0.5).add(1).mul(10)
-        if (player.en.enhancerLevels[0].gt(10000)) player.en.enhancerXPReq[0] = player.en.enhancerLevels[0].pow(0.65).add(1).mul(10)
-        
-        player.en.enhancerXPReq[1] = player.en.enhancerLevels[1].pow(0.65).add(1).mul(1000)
-        if (player.en.enhancerLevels[1].gt(10000)) player.en.enhancerXPReq[1] = player.en.enhancerLevels[1].pow(0.75).add(1).mul(1000)
-
-        player.en.enhancerXPReq[2] = player.en.enhancerLevels[2].pow(0.75).add(1).mul(25000)
-        if (player.en.enhancerLevels[2].gt(10000)) player.en.enhancerXPReq[2] = player.en.enhancerLevels[2].pow(0.85).add(1).mul(25000)
 
         player.en.enhancersEffect[0] = player.en.enhancerLevels[0].pow(0.75).add(1)
         player.en.enhancersEffect[1] = player.en.enhancerLevels[1].pow(0.8).div(50).add(1)

--- a/js/DarkU1/spaceEnergy.js
+++ b/js/DarkU1/spaceEnergy.js
@@ -75,14 +75,14 @@
         player.ds.widthPerSecond = player.ds.widthPerSecond.mul(buyableEffect("ds", 106))
         player.ds.widthPerSecond = player.ds.widthPerSecond.mul(buyableEffect("dn", 14))
         if (getLevelableTier("pu", 212, true)) player.ds.widthPerSecond = player.ds.widthPerSecond.mul(levelableEffect("pu", 212)[0])
-        player.ds.widthPerSecond = player.ds.lengthPerSecond.mul(levelableEffect("st", 302)[0])
+        player.ds.widthPerSecond = player.ds.widthPerSecond.mul(levelableEffect("st", 302)[0])
 
         player.ds.depth = player.ds.depth.add(player.ds.depthPerSecond.mul(delta))
         player.ds.depthPerSecond = buyableEffect("ds", 13)
         player.ds.depthPerSecond = player.ds.depthPerSecond.mul(buyableEffect("ds", 106))
         player.ds.depthPerSecond = player.ds.depthPerSecond.mul(buyableEffect("dn", 14))
         if (getLevelableTier("pu", 212, true)) player.ds.depthPerSecond = player.ds.depthPerSecond.mul(levelableEffect("pu", 212)[0])
-        player.ds.depthPerSecond = player.ds.lengthPerSecond.mul(levelableEffect("st", 302)[0])
+        player.ds.depthPerSecond = player.ds.depthPerSecond.mul(levelableEffect("st", 302)[0])
 
         player.ds.spissitude = player.ds.spissitude.add(player.ds.spissitudePerSecond.mul(delta))
         player.ds.spissitudePerSecond = buyableEffect("ds", 14)

--- a/js/Hex/power.js
+++ b/js/Hex/power.js
@@ -29,7 +29,6 @@ addLayer("hpw", {
         player.hpw.powerGain = player.hpw.powerGain.mul(buyableEffect("al", 206))
         if (player.alephsChamber.milestone[25] > 0) player.hpw.powerGain = player.hpw.powerGain.mul(36)
         player.hpw.powerGain = player.hpw.powerGain.mul(levelableEffect("car", 305)[0])
-        player.hpw.powerGain = player.hpw.powerGain.mul(buyableEffect("zd", 12))
 
         // POWER MODIFIERS
         player.hpw.powerGain = player.hpw.powerGain.pow(levelableEffect("pu", 210)[1])

--- a/js/Hive/flower.js
+++ b/js/Hive/flower.js
@@ -369,6 +369,7 @@ addLayer("fl", {
         if (hasUpgrade("al", 213)) player.fl.flowerGain = player.fl.flowerGain.mul(player.ho.effects.flower.effect2)
         player.fl.flowerGain = player.fl.flowerGain.mul(player.bpl.roles.empress.effect)
         player.fl.flowerGain = player.fl.flowerGain.mul(player.bee.preAlephMult)
+        if (hasUpgrade("za", 22)) player.fl.flowerGain = player.fl.flowerGain.mul(upgradeEffect("za", 22))
         player.fl.flowerGain = player.fl.flowerGain.mul(buyableEffect("tw", 22))
 
         // FLOWER AUTOMATION

--- a/js/Hive/honey.js
+++ b/js/Hive/honey.js
@@ -89,7 +89,6 @@ addLayer("ho", {
         if (hasUpgrade("ho", 4)) player.ho.cellGain = player.ho.cellGain.mul(upgradeEffect("ho", 4))
         if (hasUpgrade("al", 202)) player.ho.cellGain = player.ho.cellGain.mul(2)
         player.ho.cellGain = player.ho.cellGain.mul(player.bee.preAlephMult)
-        if (hasUpgrade("za", 22)) player.ho.cellGain = player.ho.cellGain.mul(upgradeEffect("za", 22))
         player.ho.cellGain = player.ho.cellGain.mul(buyableEffect("tw", 44))
 
         //FLOOR VALUE

--- a/js/Hive/nest.js
+++ b/js/Hive/nest.js
@@ -88,7 +88,7 @@ addLayer("n", {
             player.n.pylonEnergyPerSecond = player.n.pylonEnergyPerSecond.mul(buyableEffect("n", 3))
             player.n.pylonEnergyPerSecond = player.n.pylonEnergyPerSecond.mul(player.s.pylonEnergyEffect4)
 
-            player.n.pylonPassiveEffect = player.bee.bees.add(1).log(10).pow(0.06).div(6).add(1).pow(player.n.pylonTierEffect)
+            player.n.pylonPassiveEffect = player.bee.bees.add(1).log(10).pow(0.05).sub(1).div(5).add(1.1).pow(player.n.pylonTierEffect)
         } else {
             player.n.pylonEnergyPerSecond = new Decimal(0)
 

--- a/js/Hive/unih.js
+++ b/js/Hive/unih.js
@@ -74,12 +74,12 @@ addLayer("bee", {
         if (hasUpgrade("al", 216)) player.bee.bps = player.bee.bps.mul(upgradeEffect("al", 216))
         player.bee.bps = player.bee.bps.mul(player.bee.preAlephMult)
         if (hasUpgrade("n", 21)) player.bee.bps = player.bee.bps.mul(player.al.honeycombEffect)
-        player.bee.bps = player.bee.bps.mul(levelableEffect("car", 312)[0])
         player.bee.bps = player.bee.bps.mul(buyableEffect("tw", 23))
 
         // POWER MODIFIERS
         player.bee.bps = player.bee.bps.pow(buyableEffect("bee", 15))
         player.bee.bps = player.bee.bps.pow(buyableEffect("sme", 175))
+        player.bee.bps = player.bee.bps.pow(levelableEffect("car", 312)[0])
 
         player.bee.bees = player.bee.bees.add(player.bee.bps.mul(delta))
 

--- a/js/Zar/cards.js
+++ b/js/Zar/cards.js
@@ -66,6 +66,8 @@
 
         if (player.car.cardGenerators.gte(1)) {
             player.car.cardPointsPerSecond = [new Decimal(1), new Decimal(1), new Decimal(1), new Decimal(1)] 
+        } else {
+            player.car.cardPointsPerSecond = [new Decimal(0), new Decimal(0), new Decimal(0), new Decimal(0)] 
         }
 
         player.car.cardPointsPerSecond[0] = player.car.cardPointsPerSecond[0].mul(buyableEffect("car", 11))

--- a/js/Zar/cards.js
+++ b/js/Zar/cards.js
@@ -203,7 +203,7 @@
     clickables: {
         1: {
             title() {return "Level Up"},
-            canClick() {return getLevelableXP("car", layers.car.levelables.index).gte(tmp.car.levelables[layers.car.levelables.index].xpReq) && layers.car.levelables.index != 0},
+            canClick() {return Decimal.lt(getLevelableAmount("car", layers.car.levelables.index), layers.car.levelables[layers.car.levelables.index].levelLimit()) && getLevelableXP("car", layers.car.levelables.index).gte(tmp.car.levelables[layers.car.levelables.index].xpReq) && layers.car.levelables.index != 0},
             unlocked() {return true},
             onClick() {
                 addLevelableXP("car", layers.car.levelables.index, tmp.car.levelables[layers.car.levelables.index].xpReq.neg())
@@ -287,6 +287,7 @@
         0: {
             image() { return "resources/Punchcards/lockedPunchcard.png"},
             title() { return "No Card Selected." },
+            levelLimit() { return new Decimal(99) },
             description() { return "" },
             canSelect: false,
             currency() { return getLevelableXP(this.layer, this.id) },
@@ -1414,7 +1415,7 @@
             },
             effect() {
                 let eff = [new Decimal(1), new Decimal(1)]
-                eff[0] = getLevelableAmount(this.layer, this.id).pow(0.5).mul(0.03).add(1)
+                eff[0] = getLevelableAmount(this.layer, this.id).pow(0.5).div(40).add(1)
                 eff[1] = Decimal.pow(1.2, getLevelableAmount(this.layer, this.id).pow(0.7))
                 return eff
             },
@@ -1445,14 +1446,14 @@
             levelLimit() { return new Decimal(99) },
             description() {
                 let str = [
-                    "x" + format(this.effect()[0]) + " to hex power (affected by hex power).<br>", //not implemented
+                    "^" + format(this.effect()[0], 3) + " to hex power.<br>", //not implemented
                     "x" + format(this.effect()[1]) + " to diamond points.",
                 ]
                 return str.join("")
             },
             effect() {
                 let eff = [new Decimal(1), new Decimal(1)]
-                eff[0] = player.hpw.power.pow(0.01).pow(getLevelableAmount(this.layer, this.id).mul(0.3))
+                eff[0] = getLevelableAmount(this.layer, this.id).pow(0.5).div(50).add(1)
                 eff[1] = Decimal.pow(1.2, getLevelableAmount(this.layer, this.id).pow(0.7))
                 return eff
             },
@@ -1521,14 +1522,14 @@
             levelLimit() { return new Decimal(99) },
             description() {
                 let str = [
-                    "x" + format(this.effect()[0]) + " to infinities (affected by infinites).<br>", //not implemented
+                    "^" + formatSimple(this.effect()[0], 3) + " to infinities.<br>", //not implemented
                     "x" + format(this.effect()[1]) + " to diamond points.",
                 ]
                 return str.join("")
             },
             effect() {
                 let eff = [new Decimal(1), new Decimal(1)]
-                eff[0] = player.in.infinities.pow(0.01).pow(getLevelableAmount(this.layer, this.id).mul(0.15))
+                eff[0] = getLevelableAmount(this.layer, this.id).pow(0.6).div(200).add(1)
                 eff[1] = Decimal.pow(1.2, getLevelableAmount(this.layer, this.id).pow(0.7))
                 return eff
             },
@@ -1673,14 +1674,14 @@
             levelLimit() { return new Decimal(99) },
             description() {
                 let str = [
-                    "x" + format(this.effect()[0]) + " to stars (affected by stars).<br>", //not implemented
+                    "^" + formatSimple(this.effect()[0], 3) + " to stars.<br>", //not implemented
                     "x" + format(this.effect()[1]) + " to diamond points.",
                 ]
                 return str.join("")
             },
             effect() {
                 let eff = [new Decimal(1), new Decimal(1)]
-                eff[0] = player.au2.stars.pow(0.025).pow(getLevelableAmount(this.layer, this.id).mul(0.2)).add(1)
+                eff[0] = getLevelableAmount(this.layer, this.id).pow(0.5).div(100).add(1)
                 eff[1] = Decimal.pow(1.2, getLevelableAmount(this.layer, this.id).pow(0.7))
                 return eff
             },
@@ -1711,14 +1712,14 @@
             levelLimit() { return new Decimal(99) },
             description() {
                 let str = [
-                    "x" + format(this.effect()[0]) + " to bees (affected by bees).<br>", //not implemented
+                    "^" + formatSimple(this.effect()[0], 3) + " to bees.<br>", //not implemented
                     "x" + format(this.effect()[1]) + " to diamond points.",
                 ]
                 return str.join("")
             },
             effect() {
                 let eff = [new Decimal(1), new Decimal(1)]
-                eff[0] = player.bee.bees.pow(0.005).pow(getLevelableAmount(this.layer, this.id).mul(0.5))
+                eff[0] = getLevelableAmount(this.layer, this.id).pow(0.7).div(100).add(1)
                 eff[1] = Decimal.pow(1.2, getLevelableAmount(this.layer, this.id).pow(0.7))
                 return eff
             },

--- a/js/Zar/zar.js
+++ b/js/Zar/zar.js
@@ -275,16 +275,16 @@
             style: {color: "rgba(0,0,0,0.8)", border: "3px solid rgba(15, 12, 12, 0.5)", borderRadius: "15px", margin: "2px"},
         },
         22: {
-            title: "I don't like bees but I do like honey.",
+            title: "I don't like bees but I do like flowers.",
             unlocked() { return hasUpgrade("za", 21) && player.al.show },
-            description: "Boosts honey-cells based on chance points.",
+            description: "Boosts flower gain based on chance points.",
             cost: new Decimal(1e40),
             currencyLocation() { return player.za },
             currencyDisplayName: "Chance Points",
             currencyInternalName: "chancePoints",
             style: {color: "rgba(0,0,0,0.8)", border: "3px solid rgba(15, 12, 12, 0.5)", borderRadius: "15px", margin: "2px", width: '150px',},
             effect() {
-                return player.za.chancePoints.pow(0.06).add(1)
+                return Decimal.pow(1.5, player.za.chancePoints.add(1).log(10).pow(0.5))
             },
             effectDisplay() { return "x" + format(upgradeEffect(this.layer, this.id)) }, // Add formatting to the effect
         },

--- a/js/Zar/zarDungeon.js
+++ b/js/Zar/zarDungeon.js
@@ -453,7 +453,7 @@
         11: {
             costBase() { return new Decimal(1) },
             costGrowth() { return new Decimal(1.25) },
-            purchaseLimit() { return new Decimal(50) },
+            purchaseLimit() { return new Decimal(100) },
             currency() { return player.zd.zarChips},
             pay(amt) { player.zd.zarChips = this.currency().sub(amt) },
             effect(x) {return Decimal.pow(4, getBuyableAmount(this.layer, this.id))},
@@ -482,14 +482,14 @@
             purchaseLimit() { return new Decimal(50) },
             currency() { return player.zd.zarChips},
             pay(amt) { player.zd.zarChips = this.currency().sub(amt) },
-            effect(x) {return Decimal.pow(2, getBuyableAmount(this.layer, this.id))},
+            effect(x) {return getBuyableAmount(this.layer, this.id).add(1)},
             unlocked: true,
             cost(x) { return this.costGrowth().pow(x || getBuyableAmount(this.layer, this.id)).mul(this.costBase()).floor() },
             canAfford() {return this.currency().gte(this.cost())},
             display() {
                 return "<h3>ZC-2</h3> (" + formatWhole(getBuyableAmount(this.layer, this.id)) + "/50)\n\
-                    Double hex power gain\n\
-                    Currently: x" + formatWhole(tmp[this.layer].buyables[this.id].effect) + "\n\ \n\
+                    Raise dice score\n\
+                    Currently: ^" + formatSimple(tmp[this.layer].buyables[this.id].effect, 2) + "\n\ \n\
                     Cost: " + formatWhole(tmp[this.layer].buyables[this.id].cost) + "<br>Zar Chips"
             },
             buy() {
@@ -583,7 +583,7 @@
         16: {
             costBase() { return new Decimal(10) },
             costGrowth() { return new Decimal(3) },
-            purchaseLimit() { return new Decimal(10) },
+            purchaseLimit() { return new Decimal(20) },
             currency() { return player.zd.zarChips},
             pay(amt) { player.zd.zarChips = this.currency().sub(amt) },
             effect(x) {return getBuyableAmount(this.layer, this.id).pow(0.5).mul(0.2)},
@@ -902,53 +902,8 @@ addLayer("zarDungeon", {
             tooltip: "You can only select Nav and Dice Five into your party.",
             canClick() { return (player.zarDungeon.navToggle || player.zarDungeon.diceFiveToggle) && player.bh.currentStage != "zarDungeon" },
             unlocked: true,
-            onClick() {          
-                if (player.bh.characters[0].id != "none")player.bh.characterData[player.bh.characters[0].id].selected = 0
-                if (player.bh.characters[1].id != "none")player.bh.characterData[player.bh.characters[1].id].selected = 0
-                if (player.bh.characters[2].id != "none")player.bh.characterData[player.bh.characters[2].id].selected = 0
-                if (player.zarDungeon.navToggle) 
-                { 
-                    player.bh.characterData["nav"].selected = true
-                    player.bh.characters[0].id = "nav"
-                    for (let i = 0; i < 4; i++) {
-                        player.bh.characters[0].skills[i].id = player.bh.characterData["nav"].skills[i]
-                    }
-                }
-                else
-                {
-                    if (player.bh.characters[0].id != "none") player.bh.characterData[player.bh.characters[0].id].selected = false
-                    player.bh.characters[0].id = "none"
-
-                    for (let i = 0; i < 4; i++) {
-                        player.bh.characters[0].skills[i].id = "none"
-                    }
-                }
-                if (hasUpgrade("zd", 11) && player.zarDungeon.diceFiveToggle) 
-                {
-                    player.bh.characterData["diceFive"].selected = true
-                    player.bh.characters[1].id = "diceFive"
-                    for (let i = 0; i < 4; i++) {
-                        player.bh.characters[1].skills[i].id = player.bh.characterData["diceFive"].skills[i]
-                    }
-                }
-                else
-                {
-                    if (player.bh.characters[1].id != "none") player.bh.characterData[player.bh.characters[1].id].selected = false
-                    player.bh.characters[1].id = "none"
-
-                    for (let i = 0; i < 4; i++) {
-                        player.bh.characters[1].skills[i].id = "none"
-                    }
-                }
-
-                if (player.bh.characters[2].id != "none") player.bh.characterData[player.bh.characters[2].id].selected = false
-                player.bh.characters[2].id = "none"
-                for (let i = 0; i < 4; i++) {
-                    player.bh.characters[2].skills[i].id = "none"
-                }
-                player.tab = "bh"
-
-                BHStageEnter("zarDungeon")
+            onClick() {
+                BHStageEnter("zarDungeon", [player.zarDungeon.navToggle ? "nav" : "none", player.zarDungeon.diceFiveToggle ? "diceFive" : "none", "none"])
 
                 setTimeout(() => {
                     for (let i = 0; i < 3; i++) {

--- a/js/Zar/zarDungeon.js
+++ b/js/Zar/zarDungeon.js
@@ -967,6 +967,34 @@ addLayer("zarDungeon", {
             },
             style: {width: "200px", minHeight: "75px", color: "white", background: "linear-gradient(45deg, #4e4e4e 0%, #868686 100%)", border: "3px solid #000", borderRadius: "20px", textShadow: "1px 1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black, 0px 0px 3px black"},
         },
+        "Auto-Enter": {
+            title() {return player.bh.autoEnter ? "<div style='margin-bottom:-20px;line-height:1'>Auto Enter<br><small>[" + BHS[player.bh.autoEnter].nameCap + "]<br>[" + formatTime(Decimal.sub(30, player.bh.autoCooldown)) + "]</small></div>" : "Auto Enter<br><small>[Disabled]"},
+            canClick: true,
+            unlocked: true,
+            tooltip: "Activates after 30 seconds when exiting a BH stage",
+            onClick() {
+                if (player.bh.autoEnter) {
+                    player.bh.autoEnter = false
+                    player.bh.autoCooldown = new Decimal(0)
+                } else {
+                    player.bh.autoEnter = "zarDungeon"
+                }
+            },
+            style: {width: "110px", minHeight: "55px", color: "var(--textColor)", background: "var(--miscButtonHover)", border: "3px solid var(--miscButton)", borderRadius: "15px"},
+        },
+        "Auto-Exit": {
+            title() {return player.bh.autoExit ? "Auto Exit<br><small>[Enabled]" : "Auto Exit<br><small>[Disabled]"},
+            canClick: true,
+            unlocked: true,
+            onClick() {
+                if (player.bh.autoExit) {
+                    player.bh.autoExit = false
+                } else {
+                    player.bh.autoExit = true
+                }
+            },
+            style: {width: "110px", minHeight: "55px", color: "var(--textColor)", background: "var(--miscButtonHover)", border: "3px solid var(--miscButton)", borderRadius: "15px"},
+        },
         "Nav-Toggle": {
             title() {return player.zarDungeon.navToggle ? "<div style='margin-bottom:-20px;line-height:1'>Nav<br><small>[Enabled]</small></div>" : "Nav<br><small>[Disabled]"},
             canClick: true,
@@ -1050,9 +1078,7 @@ addLayer("zarDungeon", {
                     }],
                 ], {width: "500px", height: "197px", background: "var(--layerBackground)"}],
                 ["style-row", [
-                    ["layer-proxy", ["bh", [
-                        ["row", [["clickable", "Auto-Enter"], ["blank", ["10px", "10px"]], ["clickable", "Auto-Exit"]]],
-                    ]]], ["blank", ["10px", "10px"]], ["clickable", "Nav-Toggle"], ["blank", ["10px", "10px"]], ["clickable", "DiceFive-Toggle"],
+                    ["clickable", "Auto-Enter"], ["blank", ["10px", "10px"]], ["clickable", "Auto-Exit"], ["blank", ["10px", "10px"]], ["clickable", "Nav-Toggle"], ["blank", ["10px", "10px"]], ["clickable", "DiceFive-Toggle"],
                 ], {width: "500px", height: "70px", background: "var(--miscButtonDisable)", borderTop: "3px solid var(--regBorder)", borderRadius: "0 0 27px 0"}],
             ], {width: "500px", height: "420px", borderLeft: "3px solid var(--regBorder)"}],
         ], {width: "1200px", height: "420px"}],
@@ -1961,7 +1987,7 @@ function zarAttackBarrage(attackVariable) {
 
 window.addEventListener('load', (event) => {
     setTimeout(() => {
-    if (player.zarDungeon.barrageActive)
+    if (player && player.zarDungeon && player.zarDungeon.barrageActive)
     {
         zarFinalAttack(0)
     }

--- a/js/dice.js
+++ b/js/dice.js
@@ -746,6 +746,8 @@
         if (hasUpgrade("cs", 801)) player.d.diceScore = player.d.diceScore.mul(10)
         if (hasUpgrade("cs", 803)) player.d.diceScore = player.d.diceScore.mul(player.d.challengeDicePointsEffect2)
 
+        player.d.diceScore = player.d.diceScore.add(1).pow(buyableEffect("zd", 12)).sub(1)
+
         if (player.d.currentBoosterRoll == 0) {
                 player.d.addDiceEffect = player.d.diceScore.mul(0.0025).pow(1.1)
                 if (player.d.addDiceEffect.gte(1)) player.d.addDiceEffect = player.d.addDiceEffect.pow(player.cs.scraps.dice.effect)
@@ -1105,6 +1107,8 @@
                 if (hasUpgrade("ep2", 13)) eff = eff.mul(upgradeEffect("ep2", 13))
                 if (hasUpgrade("cs", 801)) eff = eff.mul(10)
                 if (hasUpgrade("cs", 803)) eff = eff.mul(player.d.challengeDicePointsEffect2)
+
+                eff = eff.add(1).pow(buyableEffect("zd", 12)).sub(1)
                 eff = eff.add(1).pow(player.cs.scraps.dice.effect).sub(1)
                 return eff
             },

--- a/js/infinity.js
+++ b/js/infinity.js
@@ -185,10 +185,10 @@
         player.in.infinitiesToGet = player.in.infinitiesToGet.mul(levelableEffect("ir", 2)[1])
         player.in.infinitiesToGet = player.in.infinitiesToGet.mul(buyableEffect("cof", 23))
         if (hasUpgrade("tad", 152)) player.in.infinitiesToGet = player.in.infinitiesToGet.mul(player.in.pylonEnergyEffect2)
-        player.in.infinitiesToGet = player.in.infinitiesToGet.mul(levelableEffect("car", 307)[0])
 
         // POWER MODIFIERS
         if (player.tad.altInfinities.infected.milestone.gte(2)) player.in.infinitiesToGet = player.in.infinitiesToGet.pow(player.tad.altInfinities.infected.effect2)
+        player.in.infinitiesToGet = player.in.infinitiesToGet.pow(levelableEffect("car", 307)[0])
 
         // ABNORMAL MODIFIERS
         if (player.po.halter.infinities.enabled == 1) player.in.infinitiesToGet = player.in.infinitiesToGet.div(player.po.halter.infinities.halt)

--- a/js/mod.js
+++ b/js/mod.js
@@ -41,7 +41,7 @@
 
 // Set your version in num and name
 let VERSION = {
-	num: 190.25, // CHANGED TO NUMBER TO MAKE EASIER IN FUTURE (EX. 150 = v1.5.0)
+	num: 190.26, // CHANGED TO NUMBER TO MAKE EASIER IN FUTURE (EX. 150 = v1.5.0)
 	name: "Battle Bonanza",
 }
 
@@ -234,6 +234,9 @@ function updateStyles() {
 			break;
 		case "bh":
 			switch (player.bh.currentStage) {
+				case "darkTemple":
+					layerBG = "radial-gradient(#000, #113)"
+					break;
 				case "depth1":
 					layerBG = "black"
 					if (player.bh.combo.lt(0)) layerBG = "radial-gradient(#00000066, #22226666), #000000"
@@ -2249,5 +2252,12 @@ function fixOldSave(oldVersion){
 	if (oldVersion < 190.25) {
 		if (player.sme.buyables[135]) player.darkTemple.buyables[1005] = new Decimal(player.sme.buyables[135])
 		if (player.sme.buyables[136]) player.darkTemple.buyables[1007] = new Decimal(player.sme.buyables[136])
+	}
+}
+
+function fixOldNaN(oldVersion) {
+	if (oldVersion < 190.26 && player && player.en && Decimal.eq(player.en.enhancerLevels[0], NaN)) {
+		cleanseUniverse("A1")
+		window.location.reload();
 	}
 }

--- a/js/technical/uniSupport.js
+++ b/js/technical/uniSupport.js
@@ -65,7 +65,7 @@ function cleanseUniverse(universe) {
     let tree = universes[universe].tree
     for (let row in tree) {
         for (thing in tree[row]) {
-            player.thing = getStartLayerData(thing)
+            player.thing = getStartLayerData(tree[row][thing])
         }
     }
 }


### PR DESCRIPTION
* Fixes auto-enter crashing if set to dark temple
* Fixes reckless abandon potentially crashing the game
* Fixes cantepocalypse crashing the game
* Fixes width and depth copying lengths value
* Fixes the ability to go over card level limit
* Changed many punchcards from multipliers based on currency to power buffs
* Fixed auto-enter not working for Zars Dungeon
* Redid Zars Dungeon enter code
* Replaced last zar upgrade with one that buffs flower gain
* Replaced zc:2 upgrade with one that buffs dice score
* Changed natural pylon passive formula